### PR TITLE
Add text-align left and box-sizing to control panel container

### DIFF
--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -6,6 +6,8 @@
   -ms-user-select: none;
   user-select: none;
   cursor: default;
+  text-align: left;
+  box-sizing: border-box;
 }
 
 .control-panel input {


### PR DESCRIPTION
I put a control-panel on a center-aligned page and it took me a while to figure out why the layout was all wrong. It inherited the center alignment. So I added text-align: center to the control panel. There are probably more props that need to be specified so that it doesn't inherit the wrong properties, but this is a start!