### PR TITLE
Add log scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ var control = require('control-panel')
 
 var panel = control([
   {type: 'range', label: 'my range', min: 0, max: 100, initial: 20},
+  {type: 'range', label: 'log range', min: 0.1, max: 100, initial: 20, scale: 'log'},
   {type: 'text', label: 'my text', initial: 'my cool setting'},
   {type: 'checkbox', label: 'my checkbox', initial: true},
   {type: 'color', label: 'my color', format: 'rgb', initial: 'rgb(10,200,0)'}
@@ -63,7 +64,7 @@ The first argument is a list of inputs. Each one must have a `type` and `label` 
 Each `type` must be one of `range` • `input` • `checkbox` • `color`. Each `label` must be unique. 
 
 Some types have additional properties:
-- Inputs of type `range` can specify a `min`, `max`, and `step`
+- Inputs of type `range` can specify a `min`, `max`, and `step` (or integer `steps`). Scale can be either `'linear'` (default) or `'log'`. If a log scale, the sign of `min`, `max`, and `initial` must be the same and only `steps` is permitted (since the step size is not constant on a log scale).
 - Inputs of type `color` can specify a `format` as either `rgb` • `hex` • `array`
 
 The following optional parameters can also be passed as `opts`

--- a/components/range.js
+++ b/components/range.js
@@ -9,29 +9,103 @@ inherits(Range, EventEmitter)
 function Range (root, opts, theme, uuid) {
   if (!(this instanceof Range)) return new Range(root, opts, theme, uuid)
   var self = this
+  var scaleValue, scaleValueInverse, logmin, logmax, logsign
 
   var container = require('./container')(root, opts.label)
   require('./label')(container, opts.label, theme)
 
+  if (!!opts.step && !!opts.steps) {
+    throw new Error('Cannot specify both step and steps. Got step = ' + opts.step + ', steps = ', opts.steps)
+  }
+
   var input = container.appendChild(document.createElement('input'))
   input.type = 'range'
   input.className = 'control-panel-range-' + uuid
-  opts.max = (isnumeric(opts.max)) ? opts.max : 100
-  opts.min = (isnumeric(opts.min)) ? opts.min : 0
-  opts.step = (isnumeric(opts.step)) ? opts.step : (opts.max - opts.min) / 100
+
+
+  // Create scale functions for converting to/from the desired scale:
+  if (opts.scale === 'log') {
+    scaleValue = function (x) {
+      return logsign * Math.exp(Math.log(logmin) + (Math.log(logmax) - Math.log(logmin)) * x / 100)
+    }
+    scaleValueInverse = function (y) {
+      return (Math.log(y * logsign) - Math.log(logmin)) * 100 / (Math.log(logmax) - Math.log(logmin))
+    }
+  } else {
+    scaleValue = scaleValueInverse = function (x) {return x}
+  }
+
+  // Get initial value:
+  if (opts.scale === 'log') {
+    // Get options or set defaults:
+    opts.max = (isnumeric(opts.max)) ? opts.max : 100
+    opts.min = (isnumeric(opts.min)) ? opts.min : 0.1
+
+    // Check if all signs are valid:
+    if (opts.min * opts.max <= 0) {
+      throw new Error('Log range min/max must have the same sign and not equal zero. Got min = ' + opts.min + ', max = ' + opts.max)
+    } else {
+      // Pull these into separate variables so that opts can define the *slider* mapping
+      logmin = opts.min
+      logmax = opts.max
+      logsign = opts.min > 0 ? 1 : -1
+
+      // Got the sign so force these positive:
+      logmin = Math.abs(logmin)
+      logmax = Math.abs(logmax)
+
+      // These are now simply 0-100 to which we map the log range:
+      opts.min = 0
+      opts.max = 100
+
+      // Step is invalid for a log range:
+      if (isnumeric(opts.step)) {
+        throw new Error('Log may only use steps (integer number of steps), not a step value. Got step =' + opts.step)
+      }
+      // Default step is simply 1 in linear slider space:
+      opts.step = 1
+    }
+
+    opts.initial = scaleValueInverse(isnumeric(opts.initial) ? opts.initial : scaleValue((opts.min + opts.max) * 0.5))
+
+    if (opts.initial * scaleValueInverse(opts.max) <= 0) {
+      throw new Error('Log range initial value must have the same sign as min/max and must not equal zero. Got initial value = ' + opts.initial)
+    }
+
+  } else {
+    // If linear, this is much simpler:
+    opts.max = (isnumeric(opts.max)) ? opts.max : 100
+    opts.min = (isnumeric(opts.min)) ? opts.min : 0
+    opts.step = (isnumeric(opts.step)) ? opts.step : (opts.max - opts.min) / 100
+
+    opts.initial = isnumeric(opts.initial) ? opts.initial : (opts.min + opts.max) * 0.5
+
+  }
+
+  // If we got a number of steps, use that instead:
+  if (isnumeric(opts.steps)) {
+    opts.step = isnumeric(opts.steps) ? (opts.max - opts.min) / opts.steps : opts.step
+  }
+
+  // Quantize the initial value to the requested step:
+  var initialStep = Math.round((opts.initial - opts.min) / opts.step)
+  opts.initial = opts.min + opts.step * initialStep
+
+  // Set value on the input itself:
   input.min = opts.min
   input.max = opts.max
   input.step = opts.step
-  if (opts.initial) input.value = opts.initial
+  input.value = opts.initial
 
   css(input, {
-    width: '47.5%'
+    width: '47.5%',
   })
 
-  var value = require('./value')(container, input.value, theme, '11%')
+  var value = require('./value')(container, scaleValue(opts.initial), theme, '11%')
 
   input.oninput = function (data) {
-    value.innerHTML = data.target.value
-    self.emit('input', data.target.value)
+    var scaledValue = scaleValue(parseFloat(data.target.value))
+    value.innerHTML = scaledValue
+    self.emit('input', scaledValue)
   }
 }

--- a/components/value.js
+++ b/components/value.js
@@ -13,7 +13,8 @@ module.exports = function (root, text, theme, width) {
     paddingLeft: '1.5%',
     height: '20px',
     width: width,
-    display: 'inline-block'
+    display: 'inline-block',
+    overflow: 'hidden'
   })
 
   css(value, {

--- a/example.js
+++ b/example.js
@@ -2,14 +2,18 @@ var control = require('./')
 
 var panel = control([
   {type: 'range', label: 'range slider', min: 0, max: 100, initial: 20},
-  {type: 'range', label: 'range stepped', min: 0, max: 1, step: 0.2},
+  {type: 'range', label: 'range stepped', min: 0, max: 1, step: 0.2, initial: 0.6},
+  {type: 'range', scale: 'log', label: 'range slider (log)', min: 0.01, max: 100, initial: 1},
+  {type: 'range', scale: 'log', label: 'range stepped (log)', min: 0.01, max: 100, steps: 10, initial: 1},
+  {type: 'range', scale: 'log', label: 'range slider (-log)', min: -0.01, max: -100, initial: -20, initial: -1},
+  {type: 'range', scale: 'log', label: 'range stepped (-log)', min: -0.01, max: -100, steps: 10, initial: -1},
   {type: 'text', label: 'text', initial: 'my setting'},
   {type: 'checkbox', label: 'checkbox', initial: true},
   {type: 'color', label: 'color rgb', format: 'rgb', initial: 'rgb(100,200,100)'},
   {type: 'color', label: 'color hex', format: 'hex', initial: '#30b2ba'},
   {type: 'range', label: 'one more', min: 0, max: 10}
 ],
-  {theme: 'light', title: 'example panel', position: 'top-left'}
+  {theme: 'light', title: 'example panel', position: 'top-left', width: 400}
 )
 
 panel.on('input', function (data) {


### PR DESCRIPTION
I always desperately wanted different scales in datgui, so I added a `scale: 'log'` option to `range` that permits a log scale. It's a bit of code added, so I tried to add all the permutations to the example to make sure that log scale + steps + pos/neg all worked correctly. Some notes:

- I wrapped the return value of range in `parseFloat()`. To the best of my knowledge, the current version returns a number for the initial value, then a string after that (read value from range input = String), which seemed unpleasant.
- I quantized the initial value to a step-increment (`min + i * step`) if steps are specified. This prevents an initial value that is not otherwise achievable. This may or may not be desirable. I'm not 100% sure. Should probably clamp to min/max also.
- I had to set oveflow:hidden on the value output since decimal places get a little unwieldy sometimes. Maybe sprintf + '%g'?

<img width="426" alt="screen shot 2016-05-18 at 12 03 37 am" src="https://cloud.githubusercontent.com/assets/572717/15347134/a082ee3a-1c8c-11e6-9b7b-4a4d6a1d9557.png">