### PR TITLE
Echo initialized values into state object

### DIFF
--- a/components/checkbox.js
+++ b/components/checkbox.js
@@ -23,6 +23,10 @@ function Checkbox (root, opts, theme, uuid) {
   label.htmlFor = 'checkbox-' + opts.label + uuid
   label.className = 'control-panel-checkbox-' + uuid
 
+  setTimeout(function () {
+    self.emit('initialized', input.checked)
+  })
+
   input.onchange = function (data) {
     self.emit('input', data.target.checked)
   }

--- a/components/color.js
+++ b/components/color.js
@@ -67,6 +67,10 @@ function Color (root, opts, theme) {
     picker.$el.style.display = 'none'
   }
 
+  setTimeout(function () {
+    self.emit('initialized', initial)
+  })
+
   picker.onChange(function (hex) {
     value.innerHTML = format(hex)
     css(icon, {backgroundColor: hex})

--- a/components/range.js
+++ b/components/range.js
@@ -30,6 +30,10 @@ function Range (root, opts, theme, uuid) {
 
   var value = require('./value')(container, input.value, theme, '11%')
 
+  setTimeout(function () {
+    self.emit('initialized', parseFloat(input.value))
+  })
+
   input.oninput = function (data) {
     value.innerHTML = data.target.value
     self.emit('input', data.target.value)

--- a/components/text.js
+++ b/components/text.js
@@ -31,6 +31,10 @@ function Text (root, opts, theme) {
     color: theme.text2
   })
 
+  setTimeout(function () {
+    self.emit('initialized', input.value)
+  })
+
   input.oninput = function (data) {
     self.emit('input', data.target.value)
   }

--- a/index.js
+++ b/index.js
@@ -58,8 +58,8 @@ function Plate (items, opts) {
     opacity: 0.95
   })
 
-  if (opts.position === 'top-right' 
-    || opts.position === 'top-left' 
+  if (opts.position === 'top-right'
+    || opts.position === 'top-left'
     || opts.position === 'bottom-right'
     || opts.position === 'bottom-left') css(box, {position: 'absolute'})
 
@@ -87,6 +87,11 @@ function Plate (items, opts) {
 
   items.forEach(function (item) {
     element = components[item.type](box, item, opts.theme, id)
+
+    element.on('initialized', function (data) {
+      state[item.label] = data
+    })
+
     element.on('input', function (data) {
       state[item.label] = data
       self.emit('input', state)


### PR DESCRIPTION
If `initial` is not set for an input, the state vector shows `undefined` even though the UI makes a selection (whether that's halfway through the range, the color `#123456`, or a blank string). The result is an inconsistent UI vs. state. Of course it's correct once the input is perturbed, but it remains incorrect if a *different* input is perturbed.

This PR adds an internal `'initialized'` event that each component calls (asynchronously, seems it needs to be) so that the initialized value is read and inserted into the state object as soon as the control panel is initialized. This does not trigger an `'input'` event. Let me know if this makes sense! Thanks!