### PR TITLE
Interval slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Embeddable panel of inputs for adding parameter selection to your app or visuali
 
 > Supports the following input types
 
-> `range` • `checkbox` • `text` • `color`
+> `range` • `checkbox` • `text` • `color` • `interval`
 
 ----------------
 
@@ -60,11 +60,12 @@ The first argument is a list of inputs. Each one must have a `type` and `label` 
 {type: 'checkbox', label: 'my checkbox', initial: true}
 ```
 
-Each `type` must be one of `range` • `input` • `checkbox` • `color`. Each `label` must be unique. 
+Each `type` must be one of `range` • `input` • `checkbox` • `color` • `interval`. Each `label` must be unique. 
 
 Some types have additional properties:
 - Inputs of type `range` can specify a `min`, `max`, and `step`
 - Inputs of type `color` can specify a `format` as either `rgb` • `hex` • `array`
+- Inputs of interval obey the same semantics as `range` inputs, excep the input and ouput is a two-element array corresponding to the low/high bounds, e.g. `initial: [1, 7.5]`.
 
 The following optional parameters can also be passed as `opts`
 - `root` root element to which to append the panel

--- a/components/interval.js
+++ b/components/interval.js
@@ -1,0 +1,219 @@
+var EventEmitter = require('events').EventEmitter
+var inherits = require('inherits')
+var isnumeric = require('is-numeric')
+var css = require('dom-css')
+
+module.exports = Range
+inherits(Range, EventEmitter)
+
+function clamp (x, min, max) {
+  return Math.min(Math.max(x, min), max)
+}
+
+function Range (root, opts, theme, uuid) {
+  if (!(this instanceof Range)) return new Range(root, opts, theme, uuid)
+  var self = this
+  var scaleValue, scaleValueInverse, logmin, logmax, logsign
+
+  var container = require('./container')(root, opts.label)
+  require('./label')(container, opts.label, theme)
+
+  if (!!opts.step && !!opts.steps) {
+    throw new Error('Cannot specify both step and steps. Got step = ' + opts.step + ', steps = ', opts.steps)
+  }
+
+  var panel
+  setTimeout(function () {
+    panel = document.getElementById('control-panel' + uuid)
+  })
+
+  var input = container.appendChild(document.createElement('span'))
+  input.className = 'control-panel-interval-' + uuid
+
+  var handle = document.createElement('span')
+  handle.className = 'control-panel-interval-handle'
+  input.appendChild(handle)
+
+
+  // Create scale functions for converting to/from the desired scale:
+  if (opts.scale === 'log') {
+    scaleValue = function (x) {
+      return logsign * Math.exp(Math.log(logmin) + (Math.log(logmax) - Math.log(logmin)) * x / 100)
+    }
+    scaleValueInverse = function (y) {
+      return (Math.log(y * logsign) - Math.log(logmin)) * 100 / (Math.log(logmax) - Math.log(logmin))
+    }
+  } else {
+    scaleValue = scaleValueInverse = function (x) {return x}
+  }
+
+  if (!Array.isArray(opts.initial)) {
+    opts.initial = []
+  }
+
+  if (opts.scale === 'log') {
+    // Get options or set defaults:
+    opts.max = (isnumeric(opts.max)) ? opts.max : 100
+    opts.min = (isnumeric(opts.min)) ? opts.min : 0.1
+
+    // Check if all signs are valid:
+    if (opts.min * opts.max <= 0) {
+      throw new Error('Log range min/max must have the same sign and not equal zero. Got min = ' + opts.min + ', max = ' + opts.max)
+    } else {
+      // Pull these into separate variables so that opts can define the *slider* mapping
+      logmin = opts.min
+      logmax = opts.max
+      logsign = opts.min > 0 ? 1 : -1
+
+      // Got the sign so force these positive:
+      logmin = Math.abs(logmin)
+      logmax = Math.abs(logmax)
+
+      // These are now simply 0-100 to which we map the log range:
+      opts.min = 0
+      opts.max = 100
+
+      // Step is invalid for a log range:
+      if (isnumeric(opts.step)) {
+        throw new Error('Log may only use steps (integer number of steps), not a step value. Got step =' + opts.step)
+      }
+      // Default step is simply 1 in linear slider space:
+      opts.step = 1
+    }
+
+    opts.initial = [
+      scaleValueInverse(isnumeric(opts.initial[0]) ? opts.initial[0] : scaleValue(opts.min + (opts.max - opts.min) * 0.25)),
+      scaleValueInverse(isnumeric(opts.initial[1]) ? opts.initial[1] : scaleValue(opts.min + (opts.max - opts.min) * 0.75))
+    ]
+
+    if (scaleValue(opts.initial[0]) * scaleValue(opts.max) <= 0 || scaleValue(opts.initial[1]) * scaleValue(opts.max) <= 0) {
+      throw new Error('Log range initial value must have the same sign as min/max and must not equal zero. Got initial value = [' + scaleValue(opts.initial[0]) + ', ' + scaleValue(opts.initial[1]) + ']')
+    }
+
+  } else {
+    // If linear, this is much simpler:
+    opts.max = (isnumeric(opts.max)) ? opts.max : 100
+    opts.min = (isnumeric(opts.min)) ? opts.min : 0
+    opts.step = (isnumeric(opts.step)) ? opts.step : (opts.max - opts.min) / 100
+
+    opts.initial = [
+      isnumeric(opts.initial[0]) ? opts.initial[0] : (opts.min + opts.max) * 0.25,
+      isnumeric(opts.initial[1]) ? opts.initial[1] : (opts.min + opts.max) * 0.75
+    ]
+  }
+
+  // If we got a number of steps, use that instead:
+  if (isnumeric(opts.steps)) {
+    opts.step = isnumeric(opts.steps) ? (opts.max - opts.min) / opts.steps : opts.step
+  }
+
+  // Quantize the initial value to the requested step:
+  opts.initial[0] = opts.min + opts.step * Math.round((opts.initial[0] - opts.min) / opts.step)
+  opts.initial[1] = opts.min + opts.step * Math.round((opts.initial[1] - opts.min) / opts.step)
+
+  var value = opts.initial
+
+  function setHandleCSS () {
+    css(handle, {
+      left: ((value[0] - opts.min) / (opts.max - opts.min) * 100) + '%',
+      right: (100 - (value[1] - opts.min) / (opts.max - opts.min) * 100) + '%',
+    })
+  }
+
+  // Initialize CSS:
+  setHandleCSS()
+
+  // Display the values:
+  var lValue = require('./value')(container, scaleValue(opts.initial[0]), theme, '11%', true)
+  var rValue = require('./value')(container, scaleValue(opts.initial[1]), theme, '11%')
+
+  // An index to track what's being dragged:
+  var activeIndex = -1
+
+  function mouseX (ev) {
+    // Get mouse position in page coords relative to the container:
+    return ev.pageX - input.getBoundingClientRect().left;
+  }
+
+  function setActiveValue (fraction) {
+    if (activeIndex === -1) {
+      return
+    }
+
+    // Get the position in the range [0, 1]:
+    var lofrac = (value[0] - opts.min) / (opts.max - opts.min)
+    var hifrac = (value[1] - opts.min) / (opts.max - opts.min)
+
+
+    // Clip against the other bound:
+    if (activeIndex === 0) {
+      fraction = Math.min(hifrac, fraction)
+    } else {
+      fraction = Math.max(lofrac, fraction)
+    }
+
+    // Compute and quantize the new value:
+    var newValue = opts.min + Math.round((opts.max - opts.min) * fraction / opts.step) * opts.step
+
+    // Update value, in linearized coords:
+    value[activeIndex] = newValue
+
+    // Update and send the event:
+    setHandleCSS()
+    input.oninput();
+  }
+
+  var mousemoveListener = function (ev) {
+    var fraction = clamp(mouseX(ev) / input.offsetWidth, 0, 1)
+
+    setActiveValue(fraction)
+  }
+
+  var mouseupListener = function (ev) {
+    panel.classList.remove('control-panel-interval-dragging')
+    var fraction = clamp(mouseX(ev) / input.offsetWidth, 0, 1)
+
+    setActiveValue(fraction)
+
+    document.removeEventListener('mousemove', mousemoveListener)
+    document.removeEventListener('mouseup', mouseupListener)
+
+    activeIndex = -1
+  }
+
+  input.addEventListener('mousedown', function (ev) {
+    // Tweak control to make dragging experience a little nicer:
+    panel.classList.add('control-panel-interval-dragging')
+
+    // Get mouse position fraction:
+    var fraction = clamp(mouseX(ev) / input.offsetWidth, 0, 1)
+
+    // Get the current fraction of position --> [0, 1]:
+    var lofrac = (value[0] - opts.min) / (opts.max - opts.min)
+    var hifrac = (value[1] - opts.min) / (opts.max - opts.min)
+
+    // This is just for making decisions, so perturb it ever
+    // so slightly just in case the bounds are numerically equal:
+    lofrac -= Math.abs(opts.max - opts.min) * 1e-15
+    hifrac += Math.abs(opts.max - opts.min) * 1e-15
+
+    // Figure out which is closer:
+    var lodiff = Math.abs(lofrac - fraction)
+    var hidiff = Math.abs(hifrac - fraction)
+
+    activeIndex = lodiff < hidiff ? 0 : 1
+
+    // Attach this to *document* so that we can still drag if the mouse
+    // passes outside the container:
+    document.addEventListener('mousemove', mousemoveListener)
+    document.addEventListener('mouseup', mouseupListener)
+  })
+
+  input.oninput = function () {
+    var scaledLValue = scaleValue(value[0])
+    var scaledRValue = scaleValue(value[1])
+    lValue.innerHTML = scaledLValue
+    rValue.innerHTML = scaledRValue
+    self.emit('input', [scaledLValue, scaledRValue])
+  }
+}

--- a/components/styles/interval.css
+++ b/components/styles/interval.css
@@ -1,0 +1,33 @@
+.control-panel-interval-{{ UUID }} {
+  -webkit-appearance: none;
+  position: absolute;
+  height: 20px;
+  margin: 0px 0;
+  width: 33%;
+  left: 52.5%;
+  background-color: {{ TRACK_COLOR }};
+  cursor: ew-resize;
+
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.control-panel-interval-{{ UUID }} .control-panel-interval-handle {
+  background-color: {{ INTERVAL_COLOR }};
+  position: absolute;
+  height: 20px;
+  min-width: 1px;
+}
+#control-panel{{ UUID }}.control-panel-interval-dragging * {
+  -webkit-touch-callout: none !important;
+  -webkit-user-select: none !important;
+  -khtml-user-select: none !important;
+  -moz-user-select: none !important;
+  -ms-user-select: none !important;
+  user-select: none !important;
+
+  cursor: ew-resize !important;
+}

--- a/components/value.js
+++ b/components/value.js
@@ -1,20 +1,26 @@
 var css = require('dom-css')
 
-module.exports = function (root, text, theme, width) {
+module.exports = function (root, text, theme, width, left) {
   var background = root.appendChild(document.createElement('div'))
   var value = background.appendChild(document.createElement('span'))
 
   value.innerHTML = text
 
-  css(background, {
+  var bgcss = {
     position: 'absolute',
-    right: 0,
     backgroundColor: theme.background2,
     paddingLeft: '1.5%',
     height: '20px',
     width: width,
-    display: 'inline-block'
-  })
+    display: 'inline-block',
+    overflow: 'hidden'
+  }
+
+  if (!left) {
+    bgcss.right = 0
+  }
+
+  css(background, bgcss)
 
   css(value, {
     color: theme.text2,

--- a/example.js
+++ b/example.js
@@ -7,9 +7,12 @@ var panel = control([
   {type: 'checkbox', label: 'checkbox', initial: true},
   {type: 'color', label: 'color rgb', format: 'rgb', initial: 'rgb(100,200,100)'},
   {type: 'color', label: 'color hex', format: 'hex', initial: '#30b2ba'},
+  {type: 'interval', label: 'an interval', min: 0, max: 10, initial: [3, 4], steps: 20},
+  {type: 'interval', label: 'log interval', min: 0.1, max: 10, initial: [0.1, 1], scale: 'log', steps: 20},
+  {type: 'interval', label: 'neg log interval', min: -0.1, max: -10, initial: [-0.1, -1], scale: 'log', steps: 20},
   {type: 'range', label: 'one more', min: 0, max: 10}
 ],
-  {theme: 'light', title: 'example panel', position: 'top-left'}
+  {theme: 'light', title: 'example panel', position: 'top-left', width: 400}
 )
 
 panel.on('input', function (data) {

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function Plate (items, opts) {
   var colorcss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'color.css'))
   var rangecss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'range.css'))
   var checkboxcss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'checkbox.css'))
+  var intervalcss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'interval.css'))
 
   rangecss = String(rangecss)
     .replace(new RegExp('{{ THUMB_COLOR }}', 'g'), opts.theme.foreground1)
@@ -39,10 +40,15 @@ function Plate (items, opts) {
     .replace(new RegExp('{{ BOX_COLOR }}', 'g'), opts.theme.background2)
     .replace(new RegExp('{{ ICON_COLOR }}', 'g'), opts.theme.foreground1)
     .replace(new RegExp('{{ UUID }}', 'g'), id)
+  intervalcss = String(intervalcss)
+    .replace(new RegExp('{{ INTERVAL_COLOR }}', 'g'), opts.theme.foreground1)
+    .replace(new RegExp('{{ TRACK_COLOR }}', 'g'), opts.theme.background2)
+    .replace(new RegExp('{{ UUID }}', 'g'), id)
   insertcss(rangecss)
   insertcss(colorcss)
   insertcss(basecss)
   insertcss(checkboxcss)
+  insertcss(intervalcss)
 
   var elem = document.createElement('style')
   elem.setAttribute('type', 'text/css')
@@ -58,8 +64,8 @@ function Plate (items, opts) {
     opacity: 0.95
   })
 
-  if (opts.position === 'top-right' 
-    || opts.position === 'top-left' 
+  if (opts.position === 'top-right'
+    || opts.position === 'top-left'
     || opts.position === 'bottom-right'
     || opts.position === 'bottom-left') css(box, {position: 'absolute'})
 
@@ -75,7 +81,8 @@ function Plate (items, opts) {
     text: require('./components/text'),
     range: require('./components/range'),
     checkbox: require('./components/checkbox'),
-    color: require('./components/color')
+    color: require('./components/color'),
+    interval: require('./components/interval')
   }
 
   var element


### PR DESCRIPTION
One more! Added an interval slider that obeys the same rules as range, except you select an interval. Syntax is just `initial: [lower, upper]` and ditto output, otherwise it's the same. See:

![interval](https://cloud.githubusercontent.com/assets/572717/15350852/ce1a0abe-1ca9-11e6-86eb-d88a71ad7176.gif)

Notes:
- Hover over color isn't disabled while dragging
- haven't tested on mobile