### PR TITLE
Select menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Embeddable panel of inputs for adding parameter selection to your app or visuali
 
 > Supports the following input types
 
-> `range` • `checkbox` • `text` • `color`
+> `range` • `checkbox` • `text` • `color` • `select`
 
 ----------------
 
@@ -44,7 +44,8 @@ var panel = control([
   {type: 'range', label: 'my range', min: 0, max: 100, initial: 20},
   {type: 'text', label: 'my text', initial: 'my cool setting'},
   {type: 'checkbox', label: 'my checkbox', initial: true},
-  {type: 'color', label: 'my color', format: 'rgb', initial: 'rgb(10,200,0)'}
+  {type: 'color', label: 'my color', format: 'rgb', initial: 'rgb(10,200,0)'},
+  {type: 'select', label: 'select one', options: ['option 1', 'option 2'], initial: 'option 1'}
 ], 
   {theme: 'light', position: 'top-right'}
 )
@@ -60,11 +61,12 @@ The first argument is a list of inputs. Each one must have a `type` and `label` 
 {type: 'checkbox', label: 'my checkbox', initial: true}
 ```
 
-Each `type` must be one of `range` • `input` • `checkbox` • `color`. Each `label` must be unique. 
+Each `type` must be one of `range` • `input` • `checkbox` • `color` • `select`. Each `label` must be unique. 
 
 Some types have additional properties:
 - Inputs of type `range` can specify a `min`, `max`, and `step`
 - Inputs of type `color` can specify a `format` as either `rgb` • `hex` • `array`
+- Inputs of type `select` can specify a list of options, either as an `Array` (in which case the value is the same as the option text) or as an object containing key/value pairs (in which case the key/value pair maps to value value/label pairs).
 
 The following optional parameters can also be passed as `opts`
 - `root` root element to which to append the panel

--- a/components/select.js
+++ b/components/select.js
@@ -1,0 +1,57 @@
+var EventEmitter = require('events').EventEmitter
+var inherits = require('inherits')
+var isnumeric = require('is-numeric')
+var css = require('dom-css')
+
+module.exports = Select
+inherits(Select, EventEmitter)
+
+function Select (root, opts, theme, uuid) {
+  if (!(this instanceof Select)) return new Select(root, opts, theme, uuid)
+  var self = this
+
+  var container = require('./container')(root, opts.label)
+  require('./label')(container, opts.label, theme)
+
+  var input = document.createElement('select')
+  input.className = 'control-panel-select-' + uuid + '-dropdown'
+
+  var downTriangle = document.createElement('span')
+  downTriangle.className = 'control-panel-select-' + uuid + '-triangle control-panel-select-' + uuid + '-triangle--down'
+
+  var upTriangle = document.createElement('span')
+  upTriangle.className = 'control-panel-select-' + uuid + '-triangle control-panel-select-' + uuid + '-triangle--up'
+
+  container.appendChild(downTriangle)
+  container.appendChild(upTriangle)
+
+  if (Array.isArray(opts.options)) {
+    for (var i = 0; i < opts.options.length; i++) {
+      var option = opts.options[i]
+      var el = document.createElement('option')
+      el.value = el.textContent = option
+      if (opts.initial === option) {
+        el.selected = 'selected'
+      }
+      input.appendChild(el)
+    }
+  } else {
+    var keys = Object.keys(opts.options)
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i]
+      var el = document.createElement('option')
+      el.value = key
+      if (opts.initial === key) {
+        el.selected = 'selected'
+      }
+      el.textContent = opts.options[key]
+      input.appendChild(el)
+    }
+  }
+
+  container.appendChild(input)
+
+  input.onchange = function (data) {
+    self.emit('input', data.target.value)
+  }
+}

--- a/components/styles/select.css
+++ b/components/styles/select.css
@@ -1,0 +1,39 @@
+.control-panel-select-{{ UUID }}-dropdown {
+  display: inline-block;
+  position: absolute;
+  width: 62%;
+  padding-left: 1.5%;
+  height: 20px;
+  border: none;
+  border-radius: 0;
+  outline: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -o-appearance:none;
+  appearance:none;
+  font-family: inherit;
+  background-color: {{ BG_COLOR }};
+  color: {{ TEXT_COLOR }};
+}
+.control-panel-select-{{ UUID }}-dropdown::-ms-expand {
+  display:none;
+}
+.control-panel-select-{{ UUID }}-triangle {
+  content: ' ';
+  border-right: 3px solid transparent;
+  border-left: 3px solid transparent;
+  line-height: 20px;
+  position: absolute;
+  right: 2.5%;
+  z-index: 1;
+}
+.control-panel-select-{{ UUID }}-triangle--down {
+  top: 11px;
+  border-top: 5px solid {{ TEXT_COLOR }};
+  border-bottom: 0px transparent;
+}
+.control-panel-select-{{ UUID }}-triangle--up {
+  top: 4px;
+  border-bottom: 5px solid {{ TEXT_COLOR }};
+  border-top: 0px transparent;
+}

--- a/example.js
+++ b/example.js
@@ -7,7 +7,9 @@ var panel = control([
   {type: 'checkbox', label: 'checkbox', initial: true},
   {type: 'color', label: 'color rgb', format: 'rgb', initial: 'rgb(100,200,100)'},
   {type: 'color', label: 'color hex', format: 'hex', initial: '#30b2ba'},
-  {type: 'range', label: 'one more', min: 0, max: 10}
+  {type: 'range', label: 'one more', min: 0, max: 10},
+  {type: 'select', label: 'key/value select', options: {state1: 'State One', state2: 'State Two'}, initial: 'state1'},
+  {type: 'select', label: 'array select', options: ['State One', 'State Two'], initial: 'State One'}
 ],
   {theme: 'light', title: 'example panel', position: 'top-left'}
 )

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function Plate (items, opts) {
   var colorcss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'color.css'))
   var rangecss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'range.css'))
   var checkboxcss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'checkbox.css'))
+  var selectcss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'select.css'))
 
   rangecss = String(rangecss)
     .replace(new RegExp('{{ THUMB_COLOR }}', 'g'), opts.theme.foreground1)
@@ -39,6 +40,12 @@ function Plate (items, opts) {
     .replace(new RegExp('{{ BOX_COLOR }}', 'g'), opts.theme.background2)
     .replace(new RegExp('{{ ICON_COLOR }}', 'g'), opts.theme.foreground1)
     .replace(new RegExp('{{ UUID }}', 'g'), id)
+  selectcss = String(selectcss)
+    .replace(new RegExp('{{ TEXT_COLOR }}', 'g'), opts.theme.foreground1)
+    .replace(new RegExp('{{ BG_COLOR }}', 'g'), opts.theme.background2)
+    .replace(new RegExp('{{ BG_COLOR_HOVER }}', 'g'), opts.theme.background2hover)
+    .replace(new RegExp('{{ UUID }}', 'g'), id)
+  insertcss(selectcss)
   insertcss(rangecss)
   insertcss(colorcss)
   insertcss(basecss)
@@ -58,8 +65,8 @@ function Plate (items, opts) {
     opacity: 0.95
   })
 
-  if (opts.position === 'top-right' 
-    || opts.position === 'top-left' 
+  if (opts.position === 'top-right'
+    || opts.position === 'top-left'
     || opts.position === 'bottom-right'
     || opts.position === 'bottom-left') css(box, {position: 'absolute'})
 
@@ -75,7 +82,8 @@ function Plate (items, opts) {
     text: require('./components/text'),
     range: require('./components/range'),
     checkbox: require('./components/checkbox'),
-    color: require('./components/color')
+    color: require('./components/color'),
+    select: require('./components/select')
   }
 
   var element


### PR DESCRIPTION
One more. This one was pretty straightforward. Uses native select, styled to match to the extent possible. I haven't tested in IE, but I've done my best to ensure consistent styles across browsers. Can either supply key/value pairs or an Array of options.

![select](https://cloud.githubusercontent.com/assets/572717/15395302/2203a788-1da5-11e6-8c76-160be4565f36.gif)

And in firefox:

<img width="377" alt="screen shot 2016-05-19 at 9 30 59 am" src="https://cloud.githubusercontent.com/assets/572717/15395308/2741a736-1da5-11e6-88a2-3a2c5c8e9d28.png">
