### PR TITLE
Use smokestack

### DIFF
--- a/components/checkbox.js
+++ b/components/checkbox.js
@@ -1,6 +1,5 @@
 var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
-var uuid = require('node-uuid')
 
 module.exports = Checkbox
 inherits(Checkbox, EventEmitter)

--- a/demo/index.js
+++ b/demo/index.js
@@ -15,10 +15,10 @@ var inputs = [
   {type: 'range', label: 'one more', min: 0, max: 10}
 ]
 
-var panel1 = control(inputs,
+control(inputs,
   {theme: 'light', title: 'example panel 1', root: div1}
 )
 
-var panel2 = control(inputs,
+control(inputs,
   {theme: 'dark', title: 'example panel 2', root: div2}
 )

--- a/index.js
+++ b/index.js
@@ -58,10 +58,10 @@ function Plate (items, opts) {
     opacity: 0.95
   })
 
-  if (opts.position === 'top-right' 
-    || opts.position === 'top-left' 
-    || opts.position === 'bottom-right'
-    || opts.position === 'bottom-left') css(box, {position: 'absolute'})
+  if (opts.position === 'top-right' ||
+    opts.position === 'top-left' ||
+    opts.position === 'bottom-right' ||
+    opts.position === 'bottom-left') css(box, {position: 'absolute'})
 
   if (opts.position === 'top-right' || opts.position === 'bottom-right') css(box, {right: 8})
   else css(box, {left: 8})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "watchify-server example.js | garnish",
-    "test": "browserify test.js | smokestack | tap-spec",
+    "test": "standard && browserify test.js | smokestack | tap-spec",
     "build": "browserify demo/index.js -o demo/bundle.js",
     "deploy": "surge demo control-panel.surge.sh"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "watchify-server example.js | garnish",
-    "test": "browserify test.js | testron | tap-spec",
+    "test": "browserify test.js | smokestack | tap-spec",
     "build": "browserify demo/index.js -o demo/bundle.js",
     "deploy": "surge demo control-panel.surge.sh"
   },
@@ -46,9 +46,9 @@
   },
   "devDependencies": {
     "garnish": "^5.0.1",
+    "smokestack": "^3.4.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.1",
-    "testron": "^1.2.0",
     "watchify-server": "^1.0.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -33,4 +33,5 @@ test('checkbox', function (t) {
   t.equal(typeof document.querySelector('.input-panel-checkbox'), 'object')
   t.equal(typeof document.querySelector('#input-panel-label'), 'object')
   t.end()
+  window.close()
 })


### PR DESCRIPTION
This PR switches from `testron` to `smokestack` for the unit tests. It also fixes a few cases of non-standard formatting.