### PR TITLE
Prepare control panel for the rocket launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ var panel = control([
   {type: 'color', label: 'my color', format: 'rgb', initial: 'rgb(10,200,0)'},
   {type: 'button', label: 'gimme an alert', action: function () {alert('hello!');}},
   {type: 'select', label: 'select one', options: ['option 1', 'option 2'], initial: 'option 1'}
-], 
+],
   {theme: 'light', position: 'top-right'}
 )
 ```
@@ -63,7 +63,7 @@ The first argument is a list of inputs. Each one must have a `type` and `label` 
 {type: 'checkbox', label: 'my checkbox', initial: true}
 ```
 
-Each `type` must be one of `range` • `input` • `checkbox` • `color` • `interval` • `select`. Each `label` must be unique. 
+Each `type` must be one of `range` • `input` • `checkbox` • `color` • `interval` • `select`. Each `label` must be unique.
 
 Some types have additional properties:
 - Inputs of type `range` can specify a `min`, `max`, and `step` (or integer `steps`). Scale can be either `'linear'` (default) or `'log'`. If a log scale, the sign of `min`, `max`, and `initial` must be the same and only `steps` is permitted (since the step size is not constant on a log scale).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ var panel = control([
   {type: 'range', label: 'log range', min: 0.1, max: 100, initial: 20, scale: 'log'},
   {type: 'text', label: 'my text', initial: 'my cool setting'},
   {type: 'checkbox', label: 'my checkbox', initial: true},
-  {type: 'color', label: 'my color', format: 'rgb', initial: 'rgb(10,200,0)'},
+  {type: 'color', label: 'my color', format: 'rgb', initial: 'rgb(10,200,0)', input: function (value) {console.log(value);}},
   {type: 'button', label: 'gimme an alert', action: function () {alert('hello!');}},
   {type: 'select', label: 'select one', options: ['option 1', 'option 2'], initial: 'option 1'}
 ],
@@ -57,10 +57,10 @@ var panel = control([
 
 #### `panel = control([input1, input2, ...], [opts])`
 
-The first argument is a list of inputs. Each one must have a `type` and `label` property, and can have an `initial` property with an initial value. For example,
+The first argument is a list of inputs. Each one must have a `type` and `label` property, and can have an `initial` property with an initial value. Also it may have an `input` callback, which will be invoked if value changed. For example,
 
 ```javascript
-{type: 'checkbox', label: 'my checkbox', initial: true}
+{type: 'checkbox', label: 'my checkbox', initial: true, input: function (value) {}}
 ```
 
 Each `type` must be one of `range` • `input` • `checkbox` • `color` • `interval` • `select`. Each `label` must be unique.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ var control = require('control-panel')
 var panel = control([
   {type: 'range', label: 'my range', min: 0, max: 100, initial: 20},
   {type: 'range', label: 'log range', min: 0.1, max: 100, initial: 20, scale: 'log'},
-  {type: 'text', label: 'my text', initial: 'my cool setting'},
+  {type: 'text', label: 'my text', initial: 'my cool setting', help: 'why this is cool'},
   {type: 'checkbox', label: 'my checkbox', initial: true},
   {type: 'color', label: 'my color', format: 'rgb', initial: 'rgb(10,200,0)', input: function (value) {console.log(value);}},
   {type: 'button', label: 'gimme an alert', action: function () {alert('hello!');}},
@@ -57,7 +57,7 @@ var panel = control([
 
 #### `panel = control([input1, input2, ...], [opts])`
 
-The first argument is a list of inputs. Each one must have a `type` and `label` property, and can have an `initial` property with an initial value. Also it may have an `input` callback, which will be invoked if value changed. For example,
+The first argument is a list of inputs. Each one must have a `type`, `label` and `help` property, and can have an `initial` property with an initial value. Also it may have an `input` callback, which will be invoked if value changed. For example,
 
 ```javascript
 {type: 'checkbox', label: 'my checkbox', initial: true, input: function (value) {}}

--- a/components/button.js
+++ b/components/button.js
@@ -23,7 +23,7 @@ function Button (root, opts, theme, uuid) {
   css(input, {
     position: 'absolute',
     textAlign: 'center',
-    height: '20px',
+    height: '2em',
     width: '62%',
     border: 'none',
     cursor: 'pointer',

--- a/components/button.js
+++ b/components/button.js
@@ -8,7 +8,7 @@ inherits(Button, EventEmitter)
 function Button (root, opts, theme, uuid) {
   if (!(this instanceof Button)) return new Button(root, opts, theme, uuid)
 
-  var container = require('./container')(root, opts.label)
+  var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, '', theme)
 
   var input = container.appendChild(document.createElement('button'))

--- a/components/button.js
+++ b/components/button.js
@@ -24,7 +24,7 @@ function Button (root, opts, theme, uuid) {
     position: 'absolute',
     textAlign: 'center',
     height: '2em',
-    width: '62%',
+    width: '64%',
     border: 'none',
     cursor: 'pointer',
     right: 0,

--- a/components/checkbox.js
+++ b/components/checkbox.js
@@ -27,6 +27,7 @@ function Checkbox (root, opts, theme, uuid) {
   })
 
   input.onchange = function (data) {
+    opts.input && opts.input(data.target.checked)
     self.emit('input', data.target.checked)
   }
 }

--- a/components/checkbox.js
+++ b/components/checkbox.js
@@ -1,5 +1,6 @@
 var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
+var format = require('param-case')
 
 module.exports = Checkbox
 inherits(Checkbox, EventEmitter)
@@ -9,7 +10,7 @@ function Checkbox (root, opts, theme, uuid) {
   opts = opts || {}
   var self = this
 
-  var id = 'checkbox-' + opts.label.replace(/\s/g, '-') + '-' + uuid
+  var id = 'checkbox-' + format(opts.label) + '-' + uuid
 
   var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)

--- a/components/checkbox.js
+++ b/components/checkbox.js
@@ -9,17 +9,19 @@ function Checkbox (root, opts, theme, uuid) {
   opts = opts || {}
   var self = this
 
+  var id = 'checkbox-' + opts.label.replace(/\s/g, '-') + '-' + uuid
+
   var container = require('./container')(root, opts.label)
-  require('./label')(container, opts.label, theme)
+  require('./label')(container, opts.label, theme, id)
 
   var input = container.appendChild(document.createElement('input'))
-  input.id = 'checkbox-' + opts.label + uuid
+  input.id = id
   input.type = 'checkbox'
   input.checked = opts.initial
   input.className = 'control-panel-checkbox-' + uuid
 
   var label = container.appendChild(document.createElement('label'))
-  label.htmlFor = 'checkbox-' + opts.label + uuid
+  label.htmlFor = id
   label.className = 'control-panel-checkbox-' + uuid
 
   setTimeout(function () {

--- a/components/checkbox.js
+++ b/components/checkbox.js
@@ -11,7 +11,7 @@ function Checkbox (root, opts, theme, uuid) {
 
   var id = 'checkbox-' + opts.label.replace(/\s/g, '-') + '-' + uuid
 
-  var container = require('./container')(root, opts.label)
+  var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)
 
   var input = container.appendChild(document.createElement('input'))

--- a/components/checkbox.js
+++ b/components/checkbox.js
@@ -30,7 +30,6 @@ function Checkbox (root, opts, theme, uuid) {
   })
 
   input.onchange = function (data) {
-    opts.input && opts.input(data.target.checked)
     self.emit('input', data.target.checked)
   }
 }

--- a/components/color.js
+++ b/components/color.js
@@ -74,6 +74,7 @@ function Color (root, opts, theme, uuid) {
   picker.onChange(function (hex) {
     value.value = format(hex)
     css(icon, {backgroundColor: hex})
+    opts.input && opts.input(format(hex));
     self.emit('input', format(hex))
   })
 

--- a/components/color.js
+++ b/components/color.js
@@ -29,7 +29,10 @@ function Color (root, opts, theme, uuid) {
     theme: theme,
     width: '50%',
     uuid: uuid,
-    id: id
+    id: id,
+    change: function (v) {
+      picker.setColor(v)
+    }
   })
 
   icon.onmouseover = function () {

--- a/components/color.js
+++ b/components/color.js
@@ -20,7 +20,7 @@ function Color (root, opts, theme, uuid) {
   var icon = container.appendChild(document.createElement('span'))
   icon.className = 'control-panel-color-' + uuid
 
-  var value = require('./value')(container, '', theme, '46%')
+  var value = require('./value')(container, {initial: '', theme: theme, width: '46%', uuid: uuid})
 
   icon.onmouseover = function () {
     picker.$el.style.display = ''
@@ -72,7 +72,7 @@ function Color (root, opts, theme, uuid) {
   })
 
   picker.onChange(function (hex) {
-    value.innerHTML = format(hex)
+    value.value = format(hex)
     css(icon, {backgroundColor: hex})
     self.emit('input', format(hex))
   })

--- a/components/color.js
+++ b/components/color.js
@@ -50,7 +50,7 @@ function Color (root, opts, theme, uuid) {
   })
 
   css(picker.$el, {
-    marginTop: '20px',
+    marginTop: '2em',
     display: 'none',
     position: 'absolute'
   })
@@ -59,7 +59,7 @@ function Color (root, opts, theme, uuid) {
     position: 'relative',
     display: 'inline-block',
     width: '12.5%',
-    height: '20px',
+    height: '2em',
     backgroundColor: picker.getHexString()
   })
 

--- a/components/color.js
+++ b/components/color.js
@@ -3,7 +3,7 @@ var ColorPicker = require('simple-color-picker')
 var inherits = require('inherits')
 var css = require('dom-css')
 var tinycolor = require('tinycolor2')
-var format = require('param-case')
+var formatParam = require('param-case')
 
 module.exports = Color
 inherits(Color, EventEmitter)
@@ -15,7 +15,7 @@ function Color (root, opts, theme, uuid) {
   opts.initial = opts.initial || '#123456'
   var self = this
 
-  var id = 'control-panel-color-value-' + format(opts.label) + '-' + uuid;
+  var id = 'control-panel-color-value-' + formatParam(opts.label) + '-' + uuid
 
   var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)
@@ -84,7 +84,7 @@ function Color (root, opts, theme, uuid) {
   picker.onChange(function (hex) {
     value.value = format(hex)
     css(icon, {backgroundColor: hex})
-    opts.input && opts.input(format(hex));
+    opts.input && opts.input(format(hex))
     self.emit('input', format(hex))
   })
 

--- a/components/color.js
+++ b/components/color.js
@@ -84,7 +84,6 @@ function Color (root, opts, theme, uuid) {
   picker.onChange(function (hex) {
     value.value = format(hex)
     css(icon, {backgroundColor: hex})
-    opts.input && opts.input(format(hex))
     self.emit('input', format(hex))
   })
 

--- a/components/color.js
+++ b/components/color.js
@@ -68,7 +68,8 @@ function Color (root, opts, theme, uuid) {
   css(icon, {
     position: 'relative',
     display: 'inline-block',
-    width: '12.5%',
+    verticalAlign: 'top',
+    width: '13%',
     height: '2em',
     backgroundColor: picker.getHexString()
   })

--- a/components/color.js
+++ b/components/color.js
@@ -3,6 +3,7 @@ var ColorPicker = require('simple-color-picker')
 var inherits = require('inherits')
 var css = require('dom-css')
 var tinycolor = require('tinycolor2')
+var format = require('param-case')
 
 module.exports = Color
 inherits(Color, EventEmitter)
@@ -14,7 +15,7 @@ function Color (root, opts, theme, uuid) {
   opts.initial = opts.initial || '#123456'
   var self = this
 
-  var id = 'control-panel-color-value-' + opts.label.replace(/\s/g, '-') + '-' + uuid;
+  var id = 'control-panel-color-value-' + format(opts.label) + '-' + uuid;
 
   var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)

--- a/components/color.js
+++ b/components/color.js
@@ -20,7 +20,7 @@ function Color (root, opts, theme, uuid) {
   var icon = container.appendChild(document.createElement('span'))
   icon.className = 'control-panel-color-' + uuid
 
-  var value = require('./value')(container, {initial: '', theme: theme, width: '46%', uuid: uuid})
+  var value = require('./value')(container, {initial: '', theme: theme, width: '50%', uuid: uuid})
 
   icon.onmouseover = function () {
     picker.$el.style.display = ''

--- a/components/color.js
+++ b/components/color.js
@@ -16,7 +16,7 @@ function Color (root, opts, theme, uuid) {
 
   var id = 'control-panel-color-value-' + opts.label.replace(/\s/g, '-') + '-' + uuid;
 
-  var container = require('./container')(root, opts.label)
+  var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)
 
   var icon = container.appendChild(document.createElement('span'))

--- a/components/color.js
+++ b/components/color.js
@@ -14,13 +14,22 @@ function Color (root, opts, theme, uuid) {
   opts.initial = opts.initial || '#123456'
   var self = this
 
+  var id = 'control-panel-color-value-' + opts.label.replace(/\s/g, '-') + '-' + uuid;
+
   var container = require('./container')(root, opts.label)
-  require('./label')(container, opts.label, theme)
+  require('./label')(container, opts.label, theme, id)
 
   var icon = container.appendChild(document.createElement('span'))
+  icon.id = 'control-panel-color-' + uuid
   icon.className = 'control-panel-color-' + uuid
 
-  var value = require('./value')(container, {initial: '', theme: theme, width: '50%', uuid: uuid})
+  var value = require('./value')(container, {
+    initial: '',
+    theme: theme,
+    width: '50%',
+    uuid: uuid,
+    id: id
+  })
 
   icon.onmouseover = function () {
     picker.$el.style.display = ''

--- a/components/container.js
+++ b/components/container.js
@@ -8,7 +8,7 @@ module.exports = function (root, label, help) {
   css(container, {
     position: 'relative',
     minHeight: '2em',
-    lineHeight: '1',
+    lineHeight: '1.5',
     marginBottom: '.5em'
   })
   if (help) container.setAttribute('data-help', help)

--- a/components/container.js
+++ b/components/container.js
@@ -6,7 +6,9 @@ module.exports = function (root, label) {
   container.id = 'control-panel-' + format(label)
   css(container, {
     position: 'relative',
-    height: '2.5em'
+    minHeight: '2em',
+    lineHeight: '1',
+    marginBottom: '.5em',
   })
   return container
 }

--- a/components/container.js
+++ b/components/container.js
@@ -1,14 +1,16 @@
 var css = require('dom-css')
 var format = require('param-case')
 
-module.exports = function (root, label) {
+module.exports = function (root, label, help) {
   var container = root.appendChild(document.createElement('div'))
   container.id = 'control-panel-' + format(label)
+  container.className = 'control-panel-container'
   css(container, {
     position: 'relative',
     minHeight: '2em',
     lineHeight: '1',
     marginBottom: '.5em',
   })
+  if (help) container.setAttribute('data-help', help);
   return container
 }

--- a/components/container.js
+++ b/components/container.js
@@ -6,7 +6,7 @@ module.exports = function (root, label) {
   container.id = 'control-panel-' + format(label)
   css(container, {
     position: 'relative',
-    height: '25px'
+    height: '2.5em'
   })
   return container
 }

--- a/components/container.js
+++ b/components/container.js
@@ -9,8 +9,8 @@ module.exports = function (root, label, help) {
     position: 'relative',
     minHeight: '2em',
     lineHeight: '1',
-    marginBottom: '.5em',
+    marginBottom: '.5em'
   })
-  if (help) container.setAttribute('data-help', help);
+  if (help) container.setAttribute('data-help', help)
   return container
 }

--- a/components/interval.js
+++ b/components/interval.js
@@ -16,8 +16,10 @@ function Range (root, opts, theme, uuid) {
   var self = this
   var scaleValue, scaleValueInverse, logmin, logmax, logsign, panel, input, handle
 
+  var id = 'control-panel-interval-value-' + opts.label.replace(/\s/g, '-') + '-' + uuid;
   var container = require('./container')(root, opts.label)
-  require('./label')(container, opts.label, theme)
+  require('./label')(container, opts.label, theme, id)
+
 
   if (!!opts.step && !!opts.steps) {
     throw new Error('Cannot specify both step and steps. Got step = ' + opts.step + ', steps = ', opts.steps)
@@ -28,6 +30,7 @@ function Range (root, opts, theme, uuid) {
   })
 
   input = container.appendChild(document.createElement('span'))
+  input.id = 'control-panel-interval-' + uuid
   input.className = 'control-panel-interval-' + uuid
 
   handle = document.createElement('span')
@@ -122,8 +125,22 @@ function Range (root, opts, theme, uuid) {
   setHandleCSS()
 
   // Display the values:
-  var lValue = require('./value')(container, {initial: scaleValue(opts.initial[0]), theme: theme, width: '12%', type: 'text', left: true, uuid: uuid})
-  var rValue = require('./value')(container, {initial: scaleValue(opts.initial[1]), theme: theme, width: '12%', type: 'text', uuid: uuid})
+  var lValue = require('./value')(container, {
+    initial: scaleValue(opts.initial[0]),
+    theme: theme,
+    width: '12%',
+    type: 'text',
+    left: true,
+    id: id,
+    uuid: uuid
+  })
+  var rValue = require('./value')(container, {
+    initial: scaleValue(opts.initial[1]),
+    theme: theme,
+    width: '12%',
+    type: 'text',
+    uuid: uuid
+  })
 
   // An index to track what's being dragged:
   var activeIndex = -1

--- a/components/interval.js
+++ b/components/interval.js
@@ -2,6 +2,7 @@ var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
 var isnumeric = require('is-numeric')
 var css = require('dom-css')
+var isMobile = require('is-mobile')();
 
 module.exports = Range
 inherits(Range, EventEmitter)
@@ -128,8 +129,8 @@ function Range (root, opts, theme, uuid) {
   var activeIndex = -1
 
   function mouseX (ev) {
-    // Get mouse position in page coords relative to the container:
-    return ev.pageX - input.getBoundingClientRect().left
+    // Get mouse/touch position in page coords relative to the container:
+    return (ev.touches && ev.touches[0] || ev).pageX - input.getBoundingClientRect().left
   }
 
   function setActiveValue (fraction) {
@@ -160,6 +161,8 @@ function Range (root, opts, theme, uuid) {
   }
 
   var mousemoveListener = function (ev) {
+    if (ev.target === input || ev.target === handle) ev.preventDefault();
+
     var fraction = clamp(mouseX(ev) / input.offsetWidth, 0, 1)
 
     setActiveValue(fraction)
@@ -167,17 +170,14 @@ function Range (root, opts, theme, uuid) {
 
   var mouseupListener = function (ev) {
     panel.classList.remove('control-panel-interval-dragging')
-    var fraction = clamp(mouseX(ev) / input.offsetWidth, 0, 1)
 
-    setActiveValue(fraction)
-
-    document.removeEventListener('mousemove', mousemoveListener)
-    document.removeEventListener('mouseup', mouseupListener)
+    document.removeEventListener(isMobile ? 'touchmove' : 'mousemove', mousemoveListener)
+    document.removeEventListener(isMobile ? 'touchend' : 'mouseup', mouseupListener)
 
     activeIndex = -1
   }
 
-  input.addEventListener('mousedown', function (ev) {
+  input.addEventListener(isMobile ? 'touchstart' : 'mousedown', function (ev) {
     // Tweak control to make dragging experience a little nicer:
     panel.classList.add('control-panel-interval-dragging')
 
@@ -201,8 +201,8 @@ function Range (root, opts, theme, uuid) {
 
     // Attach this to *document* so that we can still drag if the mouse
     // passes outside the container:
-    document.addEventListener('mousemove', mousemoveListener)
-    document.addEventListener('mouseup', mouseupListener)
+    document.addEventListener(isMobile ? 'touchmove' : 'mousemove', mousemoveListener)
+    document.addEventListener(isMobile ? 'touchend' : 'mouseup', mouseupListener)
   })
 
   setTimeout(function () {

--- a/components/interval.js
+++ b/components/interval.js
@@ -2,7 +2,7 @@ var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
 var isnumeric = require('is-numeric')
 var css = require('dom-css')
-var isMobile = require('is-mobile')();
+var isMobile = require('is-mobile')()
 var format = require('param-case')
 
 module.exports = Range
@@ -17,10 +17,9 @@ function Range (root, opts, theme, uuid) {
   var self = this
   var scaleValue, scaleValueInverse, logmin, logmax, logsign, panel, input, handle
 
-  var id = 'control-panel-interval-value-' + format(opts.label) + '-' + uuid;
+  var id = 'control-panel-interval-value-' + format(opts.label) + '-' + uuid
   var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)
-
 
   if (!!opts.step && !!opts.steps) {
     throw new Error('Cannot specify both step and steps. Got step = ' + opts.step + ', steps = ', opts.steps)
@@ -179,7 +178,7 @@ function Range (root, opts, theme, uuid) {
   }
 
   var mousemoveListener = function (ev) {
-    if (ev.target === input || ev.target === handle) ev.preventDefault();
+    if (ev.target === input || ev.target === handle) ev.preventDefault()
 
     var fraction = clamp(mouseX(ev) / input.offsetWidth, 0, 1)
 

--- a/components/interval.js
+++ b/components/interval.js
@@ -121,8 +121,8 @@ function Range (root, opts, theme, uuid) {
   setHandleCSS()
 
   // Display the values:
-  var lValue = require('./value')(container, scaleValue(opts.initial[0]), theme, '11%', true)
-  var rValue = require('./value')(container, scaleValue(opts.initial[1]), theme, '11%')
+  var lValue = require('./value')(container, {initial: scaleValue(opts.initial[0]), theme: theme, width: '11%', type: 'text', left: true, uuid: uuid})
+  var rValue = require('./value')(container, {initial: scaleValue(opts.initial[1]), theme: theme, width: '11%', type: 'text', uuid: uuid})
 
   // An index to track what's being dragged:
   var activeIndex = -1
@@ -208,16 +208,16 @@ function Range (root, opts, theme, uuid) {
   setTimeout(function () {
     var scaledLValue = scaleValue(value[0])
     var scaledRValue = scaleValue(value[1])
-    lValue.innerHTML = scaledLValue
-    rValue.innerHTML = scaledRValue
+    lValue.value = scaledLValue
+    rValue.value = scaledRValue
     self.emit('initialized', [scaledLValue, scaledRValue])
   })
 
   input.oninput = function () {
     var scaledLValue = scaleValue(value[0])
     var scaledRValue = scaleValue(value[1])
-    lValue.innerHTML = scaledLValue
-    rValue.innerHTML = scaledRValue
+    lValue.value = scaledLValue
+    rValue.value = scaledRValue
     self.emit('input', [scaledLValue, scaledRValue])
   }
 }

--- a/components/interval.js
+++ b/components/interval.js
@@ -17,7 +17,7 @@ function Range (root, opts, theme, uuid) {
   var scaleValue, scaleValueInverse, logmin, logmax, logsign, panel, input, handle
 
   var id = 'control-panel-interval-value-' + opts.label.replace(/\s/g, '-') + '-' + uuid;
-  var container = require('./container')(root, opts.label)
+  var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)
 
 

--- a/components/interval.js
+++ b/components/interval.js
@@ -3,6 +3,7 @@ var inherits = require('inherits')
 var isnumeric = require('is-numeric')
 var css = require('dom-css')
 var isMobile = require('is-mobile')();
+var format = require('param-case')
 
 module.exports = Range
 inherits(Range, EventEmitter)
@@ -16,7 +17,7 @@ function Range (root, opts, theme, uuid) {
   var self = this
   var scaleValue, scaleValueInverse, logmin, logmax, logsign, panel, input, handle
 
-  var id = 'control-panel-interval-value-' + opts.label.replace(/\s/g, '-') + '-' + uuid;
+  var id = 'control-panel-interval-value-' + format(opts.label) + '-' + uuid;
   var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)
 

--- a/components/interval.js
+++ b/components/interval.js
@@ -235,7 +235,6 @@ function Range (root, opts, theme, uuid) {
     var scaledRValue = scaleValue(value[1])
     lValue.value = scaledLValue
     rValue.value = scaledRValue
-    opts.input && opts.input([scaledLValue, scaledRValue])
     self.emit('input', [scaledLValue, scaledRValue])
   }
 }

--- a/components/interval.js
+++ b/components/interval.js
@@ -122,8 +122,8 @@ function Range (root, opts, theme, uuid) {
   setHandleCSS()
 
   // Display the values:
-  var lValue = require('./value')(container, {initial: scaleValue(opts.initial[0]), theme: theme, width: '11%', type: 'text', left: true, uuid: uuid})
-  var rValue = require('./value')(container, {initial: scaleValue(opts.initial[1]), theme: theme, width: '11%', type: 'text', uuid: uuid})
+  var lValue = require('./value')(container, {initial: scaleValue(opts.initial[0]), theme: theme, width: '12%', type: 'text', left: true, uuid: uuid})
+  var rValue = require('./value')(container, {initial: scaleValue(opts.initial[1]), theme: theme, width: '12%', type: 'text', uuid: uuid})
 
   // An index to track what's being dragged:
   var activeIndex = -1

--- a/components/interval.js
+++ b/components/interval.js
@@ -218,6 +218,7 @@ function Range (root, opts, theme, uuid) {
     var scaledRValue = scaleValue(value[1])
     lValue.value = scaledLValue
     rValue.value = scaledRValue
+    opts.input && opts.input([scaledLValue, scaledRValue])
     self.emit('input', [scaledLValue, scaledRValue])
   }
 }

--- a/components/interval.js
+++ b/components/interval.js
@@ -128,7 +128,7 @@ function Range (root, opts, theme, uuid) {
   var lValue = require('./value')(container, {
     initial: scaleValue(opts.initial[0]),
     theme: theme,
-    width: '12%',
+    width: '13%',
     type: 'text',
     left: true,
     id: id,
@@ -137,7 +137,7 @@ function Range (root, opts, theme, uuid) {
   var rValue = require('./value')(container, {
     initial: scaleValue(opts.initial[1]),
     theme: theme,
-    width: '12%',
+    width: '13%',
     type: 'text',
     uuid: uuid
   })

--- a/components/label.js
+++ b/components/label.js
@@ -6,7 +6,7 @@ module.exports = function (root, text, theme) {
     left: 0,
     width: '36%',
     display: 'inline-block',
-    height: '20px',
+    height: '2em',
     paddingRight: '2%',
     verticalAlign: 'top'
   })

--- a/components/label.js
+++ b/components/label.js
@@ -1,12 +1,14 @@
 var css = require('dom-css')
 
 module.exports = function (root, text, theme) {
-  var background = root.appendChild(document.createElement('div'))
+  var background = root.appendChild(document.createElement('label'))
+  background.for = '';
   css(background, {
     left: 0,
     width: '36%',
     display: 'inline-block',
-    height: '2em',
+    paddingTop: '.2em',
+    lineHeight: '1.5',
     paddingRight: '2%',
     verticalAlign: 'top'
   })
@@ -16,7 +18,7 @@ module.exports = function (root, text, theme) {
   css(label, {
     color: theme.text1,
     display: 'inline-block',
-    verticalAlign: 'sub'
+    verticalAlign: 'top'
   })
   return label
 }

--- a/components/label.js
+++ b/components/label.js
@@ -1,14 +1,16 @@
 var css = require('dom-css')
 
-module.exports = function (root, text, theme) {
+module.exports = function (root, text, theme, id) {
   var background = root.appendChild(document.createElement('label'))
-  background.for = '';
+  background.htmlFor = id || text
+
   css(background, {
     left: 0,
     width: '36%',
     display: 'inline-block',
-    paddingTop: '.2em',
-    lineHeight: '1.5',
+    paddingTop: '.3em',
+    marginBottom: '.5em',
+    lineHeight: '1.25',
     paddingRight: '2%',
     verticalAlign: 'top'
   })

--- a/components/label.js
+++ b/components/label.js
@@ -7,9 +7,8 @@ module.exports = function (root, text, theme, id) {
   css(background, {
     left: 0,
     width: '36%',
+    paddingTop: '.45em',
     display: 'inline-block',
-    marginTop: '.4em',
-    marginBottom: '.5em',
     lineHeight: '1.25',
     paddingRight: '2%',
     verticalAlign: 'top'

--- a/components/label.js
+++ b/components/label.js
@@ -8,7 +8,7 @@ module.exports = function (root, text, theme, id) {
     left: 0,
     width: '36%',
     display: 'inline-block',
-    paddingTop: '.3em',
+    marginTop: '.4em',
     marginBottom: '.5em',
     lineHeight: '1.25',
     paddingRight: '2%',

--- a/components/range.js
+++ b/components/range.js
@@ -106,7 +106,7 @@ function Range (root, opts, theme, uuid) {
     id: id,
     initial: scaleValue(opts.initial),
     theme: theme,
-    width: '12%',
+    width: '13%',
     type: opts.scale === 'log' ? 'text' : 'number',
     uuid: uuid,
     min: scaleValue(opts.min),

--- a/components/range.js
+++ b/components/range.js
@@ -98,7 +98,20 @@ function Range (root, opts, theme, uuid) {
     width: '47.5%'
   })
 
-  var value = require('./value')(container, scaleValue(opts.initial), theme, '11%')
+  var value = require('./value')(container, {
+    initial: scaleValue(opts.initial),
+    theme: theme,
+    width: '11%',
+    type: opts.scale === 'log' ? 'text' : 'number',
+    uuid: uuid,
+    min: scaleValue(opts.min),
+    max: scaleValue(opts.max),
+    step: opts.step,
+    input: function (v) {
+      input.value = v;
+      value.value = scaleValue(v);
+    }
+  })
 
   setTimeout(function () {
     self.emit('initialized', parseFloat(input.value))
@@ -106,7 +119,7 @@ function Range (root, opts, theme, uuid) {
 
   input.oninput = function (data) {
     var scaledValue = scaleValue(parseFloat(data.target.value))
-    value.innerHTML = scaledValue
+    value.value = scaledValue
     self.emit('input', scaledValue)
   }
 }

--- a/components/range.js
+++ b/components/range.js
@@ -11,8 +11,10 @@ function Range (root, opts, theme, uuid) {
   var self = this
   var scaleValue, scaleValueInverse, logmin, logmax, logsign
 
+  var id = 'control-panel-range-value-' + opts.label + '-' + uuid
+
   var container = require('./container')(root, opts.label)
-  require('./label')(container, opts.label, theme)
+  require('./label')(container, opts.label, theme, id)
 
   if (!!opts.step && !!opts.steps) {
     throw new Error('Cannot specify both step and steps. Got step = ' + opts.step + ', steps = ', opts.steps)
@@ -21,6 +23,7 @@ function Range (root, opts, theme, uuid) {
   var input = container.appendChild(document.createElement('input'))
   input.type = 'range'
   input.className = 'control-panel-range-' + uuid
+  input.id = 'control-panel-range-' + uuid
 
   // Create scale functions for converting to/from the desired scale:
   if (opts.scale === 'log') {
@@ -99,6 +102,7 @@ function Range (root, opts, theme, uuid) {
   })
 
   var value = require('./value')(container, {
+    id: id,
     initial: scaleValue(opts.initial),
     theme: theme,
     width: '12%',

--- a/components/range.js
+++ b/components/range.js
@@ -2,6 +2,7 @@ var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
 var isnumeric = require('is-numeric')
 var css = require('dom-css')
+var format = require('param-case')
 
 module.exports = Range
 inherits(Range, EventEmitter)
@@ -11,7 +12,7 @@ function Range (root, opts, theme, uuid) {
   var self = this
   var scaleValue, scaleValueInverse, logmin, logmax, logsign
 
-  var id = 'control-panel-range-value-' + opts.label + '-' + uuid
+  var id = 'control-panel-range-value-' + format(opts.label) + '-' + uuid
 
   var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)

--- a/components/range.js
+++ b/components/range.js
@@ -120,6 +120,7 @@ function Range (root, opts, theme, uuid) {
   input.oninput = function (data) {
     var scaledValue = scaleValue(parseFloat(data.target.value))
     value.value = scaledValue
+    opts.input && opts.input(scaledValue)
     self.emit('input', scaledValue)
   }
 }

--- a/components/range.js
+++ b/components/range.js
@@ -13,7 +13,7 @@ function Range (root, opts, theme, uuid) {
 
   var id = 'control-panel-range-value-' + opts.label + '-' + uuid
 
-  var container = require('./container')(root, opts.label)
+  var container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)
 
   if (!!opts.step && !!opts.steps) {

--- a/components/range.js
+++ b/components/range.js
@@ -113,8 +113,8 @@ function Range (root, opts, theme, uuid) {
     max: scaleValue(opts.max),
     step: opts.step,
     input: function (v) {
-      input.value = v;
-      value.value = scaleValue(v);
+      input.value = v
+      value.value = scaleValue(v)
     }
   })
 

--- a/components/range.js
+++ b/components/range.js
@@ -95,13 +95,13 @@ function Range (root, opts, theme, uuid) {
   input.value = opts.initial
 
   css(input, {
-    width: '47.5%'
+    width: '50%'
   })
 
   var value = require('./value')(container, {
     initial: scaleValue(opts.initial),
     theme: theme,
-    width: '11%',
+    width: '12%',
     type: opts.scale === 'log' ? 'text' : 'number',
     uuid: uuid,
     min: scaleValue(opts.min),

--- a/components/range.js
+++ b/components/range.js
@@ -125,7 +125,6 @@ function Range (root, opts, theme, uuid) {
   input.oninput = function (data) {
     var scaledValue = scaleValue(parseFloat(data.target.value))
     value.value = scaledValue
-    opts.input && opts.input(scaledValue)
     self.emit('input', scaledValue)
   }
 }

--- a/components/select.js
+++ b/components/select.js
@@ -55,7 +55,6 @@ function Select (root, opts, theme, uuid) {
   container.appendChild(input)
 
   input.onchange = function (data) {
-    opts.input && opts.input(data.target.value)
     self.emit('input', data.target.value)
   }
 }

--- a/components/select.js
+++ b/components/select.js
@@ -51,6 +51,7 @@ function Select (root, opts, theme, uuid) {
   container.appendChild(input)
 
   input.onchange = function (data) {
+    opts.input && opts.input(data.target.value)
     self.emit('input', data.target.value)
   }
 }

--- a/components/select.js
+++ b/components/select.js
@@ -9,10 +9,13 @@ function Select (root, opts, theme, uuid) {
   var self = this
   var i, container, input, downTriangle, upTriangle, key, option, el, keys
 
+  var id = 'control-panel-select-' + opts.label.replace(/\s/g, '-') + '-' + uuid
+
   container = require('./container')(root, opts.label)
-  require('./label')(container, opts.label, theme)
+  require('./label')(container, opts.label, theme, id)
 
   input = document.createElement('select')
+  input.id = id
   input.className = 'control-panel-select-' + uuid + '-dropdown'
 
   downTriangle = document.createElement('span')

--- a/components/select.js
+++ b/components/select.js
@@ -1,5 +1,6 @@
 var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
+var format = require('param-case')
 
 module.exports = Select
 inherits(Select, EventEmitter)
@@ -9,7 +10,7 @@ function Select (root, opts, theme, uuid) {
   var self = this
   var i, container, input, downTriangle, upTriangle, key, option, el, keys
 
-  var id = 'control-panel-select-' + opts.label.replace(/\s/g, '-') + '-' + uuid
+  var id = 'control-panel-select-' + format(opts.label) + '-' + uuid
 
   container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)

--- a/components/select.js
+++ b/components/select.js
@@ -11,7 +11,7 @@ function Select (root, opts, theme, uuid) {
 
   var id = 'control-panel-select-' + opts.label.replace(/\s/g, '-') + '-' + uuid
 
-  container = require('./container')(root, opts.label)
+  container = require('./container')(root, opts.label, opts.help)
   require('./label')(container, opts.label, theme, id)
 
   input = document.createElement('select')

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -10,11 +10,20 @@
   box-sizing: border-box;
 }
 
+.control-panel * {
+  box-sizing: border-box;
+}
+
 .control-panel input,
 .control-panel button,
 .control-panel select {
+  padding: 0 0 0 .5em;
   font-size: 12px;
   font-family: monospace;
+}
+
+.control-panel input[type="range"] {
+  padding: 0;
 }
 
 .control-panel a {

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -20,8 +20,8 @@
   border-radius: 0;
   padding: 0 0 0 .5em;
   vertical-align: top;
-  font-family: {{ FONT_FAMILY }};
-  font-size: {{ FONT_SIZE }};
+  font-family: inherit;
+  font-size: inherit;
 }
 
 .control-panel input[type="range"] {

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -1,6 +1,6 @@
 .control-panel {
   font-family: monospace;
-  font-size: 12px;
+  font-size: 11px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -19,7 +19,7 @@
 .control-panel select {
   border-radius: 0;
   padding: 0 0 0 .5em;
-  font-size: 12px;
+  font-size: 11px;
   font-family: monospace;
 }
 

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -1,6 +1,4 @@
 .control-panel {
-  font-family: monospace;
-  font-size: 11px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -8,6 +6,8 @@
   cursor: default;
   text-align: left;
   box-sizing: border-box;
+  font-family: {{ FONT_FAMILY }};
+  font-size: {{ FONT_SIZE }};
 }
 
 .control-panel * {
@@ -19,9 +19,9 @@
 .control-panel select {
   border-radius: 0;
   padding: 0 0 0 .5em;
-  font-size: 11px;
   vertical-align: top;
-  font-family: monospace;
+  font-family: {{ FONT_FAMILY }};
+  font-size: {{ FONT_SIZE }};
 }
 
 .control-panel input[type="range"] {

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -31,3 +31,10 @@
   color: inherit;
   text-decoration: none;
 }
+
+.control-panel-container:after {
+  content: attr(data-help);
+  display: block;
+  color: {{ HELP_COLOR }};
+  margin-left: 36%;
+}

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -17,6 +17,7 @@
 .control-panel input,
 .control-panel button,
 .control-panel select {
+  border-radius: 0;
   padding: 0 0 0 .5em;
   font-size: 12px;
   font-family: monospace;

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -20,6 +20,7 @@
   border-radius: 0;
   padding: 0 0 0 .5em;
   font-size: 11px;
+  vertical-align: top;
   font-family: monospace;
 }
 

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -1,5 +1,5 @@
 .control-panel {
-  font-family: 'Hack', monospace;
+  font-family: monospace;
   font-size: 11px;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -11,7 +11,7 @@
 }
 
 .control-panel input {
-  font-family: 'Hack';
+  font-family: monospace;
   font-size: 11px;
 }
 

--- a/components/styles/base.css
+++ b/components/styles/base.css
@@ -1,6 +1,6 @@
 .control-panel {
   font-family: monospace;
-  font-size: 11px;
+  font-size: 12px;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -10,9 +10,11 @@
   box-sizing: border-box;
 }
 
-.control-panel input {
+.control-panel input,
+.control-panel button,
+.control-panel select {
+  font-size: 12px;
   font-family: monospace;
-  font-size: 11px;
 }
 
 .control-panel a {

--- a/components/styles/checkbox.css
+++ b/components/styles/checkbox.css
@@ -6,21 +6,21 @@ input[type="checkbox"].control-panel-checkbox-{{ UUID }} {
 input[type=checkbox].control-panel-checkbox-{{ UUID }} + label:before {
   content: "";
   display: inline-block;
-  width: 1.8em;
-  height: 1.8em;
+  width: 2em;
+  height: 2em;
   padding: 0px;
   vertical-align:middle;
   margin-right: .8em;
-  margin-top: .2em;
+  margin-top: .15em;
   background-color: {{ BOX_COLOR }};
   border-radius: 0px;
   cursor: pointer;
 }
 
 input[type=checkbox]:checked.control-panel-checkbox-{{ UUID }}  + label:before {
-  width: 1em;
-  height: 1em;
+  width: 2em;
+  height: 2em;
+  box-shadow: inset 0 0 0 4px {{ BOX_COLOR }};
   background-color: {{ ICON_COLOR }};
-  border: solid .4em {{ BOX_COLOR }};
   cursor: pointer;
 }

--- a/components/styles/checkbox.css
+++ b/components/styles/checkbox.css
@@ -9,9 +9,9 @@ input[type=checkbox].control-panel-checkbox-{{ UUID }} + label:before {
   width: 2em;
   height: 2em;
   padding: 0px;
-  vertical-align:middle;
+  vertical-align: top;
   margin-right: .8em;
-  margin-top: .15em;
+  margin-top: 0;
   background-color: {{ BOX_COLOR }};
   border-radius: 0px;
   cursor: pointer;

--- a/components/styles/checkbox.css
+++ b/components/styles/checkbox.css
@@ -1,26 +1,26 @@
 input[type="checkbox"].control-panel-checkbox-{{ UUID }} {
   display:none;
-  cursor: pointer; 
+  cursor: pointer;
 }
 
 input[type=checkbox].control-panel-checkbox-{{ UUID }} + label:before {
-  content: "";  
-  display: inline-block;  
-  width: 18px;  
-  height: 18px;  
+  content: "";
+  display: inline-block;
+  width: 1.8em;
+  height: 1.8em;
   padding: 0px;
   vertical-align:middle;
-  margin-right: 8px; 
-  margin-top: 2px; 
-  background-color: {{ BOX_COLOR }};  
-  border-radius: 0px; 
-  cursor: pointer; 
+  margin-right: .8em;
+  margin-top: .2em;
+  background-color: {{ BOX_COLOR }};
+  border-radius: 0px;
+  cursor: pointer;
 }
 
 input[type=checkbox]:checked.control-panel-checkbox-{{ UUID }}  + label:before {
-  width: 10px;  
-  height: 10px;  
+  width: 1em;
+  height: 1em;
   background-color: {{ ICON_COLOR }};
-  border: solid 4px {{ BOX_COLOR }};
-  cursor: pointer; 
+  border: solid .4em {{ BOX_COLOR }};
+  cursor: pointer;
 }

--- a/components/styles/checkbox.css
+++ b/components/styles/checkbox.css
@@ -1,5 +1,5 @@
 input[type="checkbox"].control-panel-checkbox-{{ UUID }} {
-  display:none;
+  display: none;
   cursor: pointer;
 }
 
@@ -20,7 +20,7 @@ input[type=checkbox].control-panel-checkbox-{{ UUID }} + label:before {
 input[type=checkbox]:checked.control-panel-checkbox-{{ UUID }}  + label:before {
   width: 2em;
   height: 2em;
-  box-shadow: inset 0 0 0 4px {{ BOX_COLOR }};
+  box-shadow: inset 0 0 0 .4em {{ BOX_COLOR }};
   background-color: {{ ICON_COLOR }};
   cursor: pointer;
 }

--- a/components/styles/interval.css
+++ b/components/styles/interval.css
@@ -1,7 +1,7 @@
 .control-panel-interval-{{ UUID }} {
   -webkit-appearance: none;
   position: absolute;
-  height: 20px;
+  height: 2em;
   margin: 0px 0;
   width: 33%;
   left: 52.5%;
@@ -18,7 +18,7 @@
 .control-panel-interval-{{ UUID }} .control-panel-interval-handle {
   background-color: {{ INTERVAL_COLOR }};
   position: absolute;
-  height: 20px;
+  height: 2em;
   min-width: 1px;
 }
 #control-panel-{{ UUID }}.control-panel-interval-dragging * {

--- a/components/styles/interval.css
+++ b/components/styles/interval.css
@@ -3,8 +3,8 @@
   position: absolute;
   height: 2em;
   margin: 0px 0;
-  width: 33%;
-  left: 52.5%;
+  width: 36%;
+  left: 50%;
   background-color: {{ TRACK_COLOR }};
   cursor: ew-resize;
 

--- a/components/styles/range.css
+++ b/components/styles/range.css
@@ -1,21 +1,26 @@
 input[type=range].control-panel-range-{{ UUID }} {
   -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
   width: 100%;
   margin: 0px 0;
+  height: 2em;
+
 }
 input[type=range].control-panel-range-{{ UUID }}:focus {
   outline: none;
 }
 input[type=range].control-panel-range-{{ UUID }}::-webkit-slider-runnable-track {
   width: 100%;
-  height: 20px;
+  height: 2em;
   cursor: ew-resize;
   background: {{ TRACK_COLOR }};
 }
 input[type=range].control-panel-range-{{ UUID }}::-webkit-slider-thumb {
-  height: 20px;
-  width: 10px;
+  height: 2em;
+  width: 1em;
   background: {{ THUMB_COLOR }};
+  border: 0;
   cursor: ew-resize;
   -webkit-appearance: none;
   margin-top: 0px;
@@ -26,19 +31,21 @@ input[type=range].control-panel-range-{{ UUID }}:focus::-webkit-slider-runnable-
 }
 input[type=range].control-panel-range-{{ UUID }}::-moz-range-track {
   width: 100%;
-  height: 20px;
+  height: 2em;
   cursor: ew-resize;
   background: {{ TRACK_COLOR }};
 }
 input[type=range].control-panel-range-{{ UUID }}::-moz-range-thumb {
-  height: 20px;
-  width: 10px;
+  border: 0px solid rgba(0, 0, 0, 0);
+  border-radius: 0px;
+  height: 2em;
+  width: 1em;
   background: {{ THUMB_COLOR }};
   cursor: ew-resize;
 }
 input[type=range].control-panel-range-{{ UUID }}::-ms-track {
   width: 100%;
-  height: 20px;
+  height: 2em;
   cursor: ew-resize;
   background: transparent;
   border-color: transparent;
@@ -51,11 +58,11 @@ input[type=range].control-panel-range-{{ UUID }}::-ms-fill-upper {
   background: {{ TRACK_COLOR }};
 }
 input[type=range].control-panel-range-{{ UUID }}::-ms-thumb {
-  width: 10px;
+  width: 1em;
   border-radius: 0px;
   background: {{ THUMB_COLOR }};
   cursor: ew-resize;
-  height: 20px;
+  height: 2em;
 }
 input[type=range].control-panel-range-{{ UUID }}:focus::-ms-fill-lower {
   background: {{ TRACK_COLOR }};
@@ -66,137 +73,3 @@ input[type=range].control-panel-range-{{ UUID }}:focus::-ms-fill-upper {
   outline: none;
 }
 
-input[type=range].control-panel-range-{{ UUID }} {
-  -webkit-appearance: none;
-  width: 100%;
-  margin: 0px 0;
-}
-input[type=range].control-panel-range-{{ UUID }}:focus {
-  outline: none;
-}
-input[type=range].control-panel-range-{{ UUID }}::-webkit-slider-runnable-track {
-  width: 100%;
-  height: 20px;
-  cursor: ew-resize;
-  background: {{ TRACK_COLOR }};
-}
-input[type=range].control-panel-range-{{ UUID }}::-webkit-slider-thumb {
-  height: 20px;
-  width: 10px;
-  background: {{ THUMB_COLOR }};
-  cursor: ew-resize;
-  -webkit-appearance: none;
-  margin-top: 0px;
-}
-input[type=range].control-panel-range-{{ UUID }}:focus::-webkit-slider-runnable-track {
-  background: {{ TRACK_COLOR }};
-  outline: none;
-}
-input[type=range].control-panel-range-{{ UUID }}::-moz-range-track {
-  width: 100%;
-  height: 20px;
-  cursor: ew-resize;
-  background: {{ TRACK_COLOR }};
-}
-input[type=range].control-panel-range-{{ UUID }}::-moz-range-thumb {
-  height: 20px;
-  width: 10px;
-  background: {{ THUMB_COLOR }};
-  cursor: ew-resize;
-}
-input[type=range].control-panel-range-{{ UUID }}::-ms-track {
-  width: 100%;
-  height: 20px;
-  cursor: ew-resize;
-  background: transparent;
-  border-color: transparent;
-  color: transparent;
-}
-input[type=range].control-panel-range-{{ UUID }}::-ms-fill-lower {
-  background: {{ TRACK_COLOR }};
-}
-input[type=range].control-panel-range-{{ UUID }}::-ms-fill-upper {
-  background: {{ TRACK_COLOR }};
-}
-input[type=range].control-panel-range-{{ UUID }}::-ms-thumb {
-  width: 10px;
-  background: {{ THUMB_COLOR }};
-  cursor: ew-resize;
-  height: 20px;
-}
-input[type=range].control-panel-range-{{ UUID }}:focus::-ms-fill-lower {
-  background: {{ TRACK_COLOR }};
-  outline: none;
-}
-input[type=range].control-panel-range-{{ UUID }}:focus::-ms-fill-upper {
-  background: {{ TRACK_COLOR }};
-  outline: none;
-}
-input[type=range].control-panel-range-{{ UUID }} {
-  -webkit-appearance: none;
-  width: 100%;
-  margin: 0px 0;
-}
-input[type=range].control-panel-range-{{ UUID }}:focus {
-  outline: none;
-}
-input[type=range].control-panel-range-{{ UUID }}::-webkit-slider-runnable-track {
-  width: 100%;
-  height: 20px;
-  cursor: ew-resize;
-  background: {{ TRACK_COLOR }};
-}
-input[type=range].control-panel-range-{{ UUID }}::-webkit-slider-thumb {
-  height: 20px;
-  width: 10px;
-  background: {{ THUMB_COLOR }};
-  cursor: ew-resize;
-  -webkit-appearance: none;
-  margin-top: 0px;
-}
-input[type=range].control-panel-range-{{ UUID }}:focus::-webkit-slider-runnable-track {
-  background: {{ TRACK_COLOR }};
-  outline: none;
-}
-input[type=range].control-panel-range-{{ UUID }}::-moz-range-track {
-  width: 100%;
-  height: 20px;
-  cursor: ew-resize;
-  background: {{ TRACK_COLOR }};
-}
-input[type=range].control-panel-range-{{ UUID }}::-moz-range-thumb {
-  border: 0px solid rgba(0, 0, 0, 0);
-  height: 20px;
-  width: 10px;
-  border-radius: 0px;
-  background: {{ THUMB_COLOR }};
-  cursor: ew-resize;
-}
-input[type=range].control-panel-range-{{ UUID }}::-ms-track {
-  width: 100%;
-  height: 20px;
-  cursor: ew-resize;
-  background: transparent;
-  border-color: transparent;
-  color: transparent;
-}
-input[type=range].control-panel-range-{{ UUID }}::-ms-fill-lower {
-  background: {{ TRACK_COLOR }};
-}
-input[type=range].control-panel-range-{{ UUID }}::-ms-fill-upper {
-  background: {{ TRACK_COLOR }};
-}
-input[type=range].control-panel-range-{{ UUID }}::-ms-thumb {
-  width: 10px;
-  background: {{ THUMB_COLOR }};
-  cursor: ew-resize;
-  height: 20px;
-}
-input[type=range].control-panel-range-{{ UUID }}:focus::-ms-fill-lower {
-  background: {{ TRACK_COLOR }};
-  outline: none;
-}
-input[type=range].control-panel-range-{{ UUID }}:focus::-ms-fill-upper {
-  background: {{ TRACK_COLOR }};
-  outline: none;
-}

--- a/components/styles/range.css
+++ b/components/styles/range.css
@@ -60,6 +60,7 @@ input[type=range].control-panel-range-{{ UUID }}::-ms-fill-upper {
 input[type=range].control-panel-range-{{ UUID }}::-ms-thumb {
   width: 1em;
   border-radius: 0px;
+  border: 0;
   background: {{ THUMB_COLOR }};
   cursor: ew-resize;
   height: 2em;

--- a/components/styles/select.css
+++ b/components/styles/select.css
@@ -3,7 +3,7 @@
   position: absolute;
   width: 62%;
   padding-left: 1.5%;
-  height: 20px;
+  height: 2em;
   border: none;
   border-radius: 0;
   outline: none;
@@ -20,20 +20,20 @@
 }
 .control-panel-select-{{ UUID }}-triangle {
   content: ' ';
-  border-right: 3px solid transparent;
-  border-left: 3px solid transparent;
-  line-height: 20px;
+  border-right: .3em solid transparent;
+  border-left: .3em solid transparent;
+  line-height: 2em;
   position: absolute;
   right: 2.5%;
   z-index: 1;
 }
 .control-panel-select-{{ UUID }}-triangle--down {
-  top: 11px;
-  border-top: 5px solid {{ TEXT_COLOR }};
-  border-bottom: 0px transparent;
+  top: 1.1em;
+  border-top: .5em solid {{ TEXT_COLOR }};
+  border-bottom: .0 transparent;
 }
 .control-panel-select-{{ UUID }}-triangle--up {
-  top: 4px;
-  border-bottom: 5px solid {{ TEXT_COLOR }};
+  top: .4em;
+  border-bottom: .5em solid {{ TEXT_COLOR }};
   border-top: 0px transparent;
 }

--- a/components/styles/select.css
+++ b/components/styles/select.css
@@ -1,7 +1,7 @@
 .control-panel-select-{{ UUID }}-dropdown {
   display: inline-block;
   position: absolute;
-  width: 62%;
+  width: 64%;
   padding-left: 1.5%;
   height: 2em;
   border: none;

--- a/components/styles/value.css
+++ b/components/styles/value.css
@@ -3,7 +3,7 @@
   -moz-appearance: none;
   -o-appearance: none;
   appearance: none;
-  padding: 0 0 0 1.5%;
+  padding: 0 0 0 .5em;
   display: inline-block;
   cursor: text;
   display: inline-block;

--- a/components/styles/value.css
+++ b/components/styles/value.css
@@ -1,0 +1,23 @@
+.control-panel-value-{{ UUID }} {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -o-appearance: none;
+  appearance: none;
+  padding: 0 0 0 1.5%;
+  display: inline-block;
+  cursor: text;
+  display: inline-block;
+  position: absolute;
+  width: 62%;
+  height: 2em;
+  border: none;
+  border-radius: 0;
+  outline: none;
+  font-family: inherit;
+  background-color: {{ BG_COLOR }};
+  color: {{ TEXT_COLOR }};
+}
+.control-panel-value-{{ UUID }}:focus {
+  outline: 0;
+  box-shadow: 0;
+}

--- a/components/text.js
+++ b/components/text.js
@@ -41,7 +41,6 @@ function Text (root, opts, theme, uuid) {
   })
 
   input.oninput = function (data) {
-    opts.input && opts.input(data.target.value)
     self.emit('input', data.target.value)
   }
 }

--- a/components/text.js
+++ b/components/text.js
@@ -17,7 +17,7 @@ function Text (root, opts, theme, uuid) {
   require('./label')(container, opts.label, theme, id)
 
   var input = container.appendChild(document.createElement('input'))
-  input.type = 'text'
+  input.type = opts.type
   input.id = id
   input.className = 'control-panel-text-' + uuid
   if (opts.initial) input.value = opts.initial

--- a/components/text.js
+++ b/components/text.js
@@ -10,10 +10,14 @@ function Text (root, opts, theme, uuid) {
   var self = this
 
   var container = require('./container')(root, opts.label)
-  require('./label')(container, opts.label, theme)
+
+  var id = 'control-panel-text-' + opts.label.replace(/\s/g, '-') + '-' + uuid
+
+  require('./label')(container, opts.label, theme, id)
 
   var input = container.appendChild(document.createElement('input'))
   input.type = 'text'
+  input.id = id
   input.className = 'control-panel-text-' + uuid
   if (opts.initial) input.value = opts.initial
 

--- a/components/text.js
+++ b/components/text.js
@@ -23,8 +23,8 @@ function Text (root, opts, theme, uuid) {
 
   css(input, {
     position: 'absolute',
-    paddingLeft: '6px',
-    height: '20px',
+    padding: '.1em .1em .1em .6em',
+    height: '2em',
     width: '59.5%',
     border: 'none',
     background: theme.background2,

--- a/components/text.js
+++ b/components/text.js
@@ -23,9 +23,8 @@ function Text (root, opts, theme, uuid) {
 
   css(input, {
     position: 'absolute',
-    padding: '.1em .1em .1em .6em',
     height: '2em',
-    width: '59.5%',
+    width: '64%',
     border: 'none',
     background: theme.background2,
     color: theme.text2,

--- a/components/text.js
+++ b/components/text.js
@@ -1,6 +1,7 @@
 var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
 var css = require('dom-css')
+var format = require('param-case')
 
 module.exports = Text
 inherits(Text, EventEmitter)
@@ -11,7 +12,7 @@ function Text (root, opts, theme, uuid) {
 
   var container = require('./container')(root, opts.label, opts.help)
 
-  var id = 'control-panel-text-' + opts.label.replace(/\s/g, '-') + '-' + uuid
+  var id = 'control-panel-text-' + format(opts.label) + '-' + uuid
 
   require('./label')(container, opts.label, theme, id)
 

--- a/components/text.js
+++ b/components/text.js
@@ -37,6 +37,7 @@ function Text (root, opts, theme, uuid) {
   })
 
   input.oninput = function (data) {
+    opts.input && opts.input(data.target.value)
     self.emit('input', data.target.value)
   }
 }

--- a/components/text.js
+++ b/components/text.js
@@ -9,7 +9,7 @@ function Text (root, opts, theme, uuid) {
   if (!(this instanceof Text)) return new Text(root, opts, theme, uuid)
   var self = this
 
-  var container = require('./container')(root, opts.label)
+  var container = require('./container')(root, opts.label, opts.help)
 
   var id = 'control-panel-text-' + opts.label.replace(/\s/g, '-') + '-' + uuid
 

--- a/components/title.js
+++ b/components/title.js
@@ -9,8 +9,9 @@ module.exports = function (root, text, theme) {
     textAlign: 'center',
     color: theme.text2,
     textTransform: 'uppercase',
-    height: '2em',
-    marginBottom: '4px'
+    lineHeight: '1.2',
+    marginTop: '0',
+    marginBottom: '1em'
   })
 
   return title

--- a/components/title.js
+++ b/components/title.js
@@ -9,7 +9,7 @@ module.exports = function (root, text, theme) {
     textAlign: 'center',
     color: theme.text2,
     textTransform: 'uppercase',
-    height: '20px',
+    height: '2em',
     marginBottom: '4px'
   })
 

--- a/components/value.js
+++ b/components/value.js
@@ -10,8 +10,16 @@ module.exports = function (root, opts) {
     if (opts.max != null) value.max = opts.max
     if (opts.step != null) value.step = opts.step
     else value.step = (opts.max - opts.min) / 100 || 1
+  }
+
+  if (opts.input) {
     value.addEventListener('input', function () {
-      opts.input && opts.input(value.value)
+      opts.input(value.value)
+    })
+  }
+  if (opts.change) {
+    value.addEventListener('change', function () {
+      opts.change(value.value)
     })
   }
 

--- a/components/value.js
+++ b/components/value.js
@@ -1,37 +1,35 @@
 var css = require('dom-css')
 
-module.exports = function (root, text, theme, width, left) {
-  var background = root.appendChild(document.createElement('div'))
-  var value = background.appendChild(document.createElement('span'))
+module.exports = function (root, opts) {
+  opts = opts || {}
+  var value = document.createElement('input')
+  value.setAttribute('type', opts.type || 'text')
 
-  value.innerHTML = text
-
-  var bgcss = {
-    position: 'absolute',
-    backgroundColor: theme.background2,
-    paddingLeft: '1.5%',
-    height: '2em',
-    width: width,
-    display: 'inline-block',
-    overflow: 'hidden'
+  if (opts.type === 'number') {
+    if (opts.min != null) value.min = opts.min
+    if (opts.max != null) value.max = opts.max
+    if (opts.step != null) value.step = opts.step
+    else value.step = (opts.max - opts.min) / 100 || 1;
+    value.addEventListener('input', function () {
+      opts.input && opts.input(value.value)
+    })
   }
 
-  if (!left) {
+  value.value = opts.initial
+
+  value.className = 'control-panel-value-' + opts.uuid
+  root.appendChild(value)
+
+
+  var bgcss = {
+    width: opts.width
+  }
+
+  if (!opts.left) {
     bgcss.right = 0
   }
 
-  css(background, bgcss)
-
-  css(value, {
-    color: theme.text2,
-    display: 'inline-block',
-    userSelect: 'text',
-    cursor: 'text',
-    overflow: 'hidden',
-    lineHeight: '2em',
-    wordBreak: 'break-all',
-    height: 20
-  })
+  css(value, bgcss)
 
   return value
 }

--- a/components/value.js
+++ b/components/value.js
@@ -17,6 +17,7 @@ module.exports = function (root, opts) {
 
   value.value = opts.initial
 
+  value.id = opts.id || 'control-panel-value-' + opts.uuid
   value.className = 'control-panel-value-' + opts.uuid
   root.appendChild(value)
 

--- a/components/value.js
+++ b/components/value.js
@@ -9,7 +9,7 @@ module.exports = function (root, opts) {
     if (opts.min != null) value.min = opts.min
     if (opts.max != null) value.max = opts.max
     if (opts.step != null) value.step = opts.step
-    else value.step = (opts.max - opts.min) / 100 || 1;
+    else value.step = (opts.max - opts.min) / 100 || 1
     value.addEventListener('input', function () {
       opts.input && opts.input(value.value)
     })
@@ -20,7 +20,6 @@ module.exports = function (root, opts) {
   value.id = opts.id || 'control-panel-value-' + opts.uuid
   value.className = 'control-panel-value-' + opts.uuid
   root.appendChild(value)
-
 
   var bgcss = {
     width: opts.width

--- a/components/value.js
+++ b/components/value.js
@@ -10,7 +10,7 @@ module.exports = function (root, text, theme, width, left) {
     position: 'absolute',
     backgroundColor: theme.background2,
     paddingLeft: '1.5%',
-    height: '20px',
+    height: '2em',
     width: width,
     display: 'inline-block',
     overflow: 'hidden'
@@ -28,7 +28,7 @@ module.exports = function (root, text, theme, width, left) {
     userSelect: 'text',
     cursor: 'text',
     overflow: 'hidden',
-    lineHeight: '20px',
+    lineHeight: '2em',
     wordBreak: 'break-all',
     height: 20
   })

--- a/example.js
+++ b/example.js
@@ -8,7 +8,7 @@ document.head.appendChild(meta);
 
 
 var panel = control([
-  {type: 'range', label: 'range slider', min: 0, max: 100, initial: 20},
+  {type: 'range', label: 'range slider', min: 0, max: 100, initial: 20, help: 'Default slider'},
   {type: 'range', label: 'range stepped', min: 0, max: 1, step: 0.2, initial: 0.6},
   {type: 'range', scale: 'log', label: 'range slider (log)', min: 0.01, max: 100, initial: 1},
   {type: 'range', scale: 'log', label: 'range stepped (log)', min: 0.01, max: 100, steps: 10, initial: 1},

--- a/example.js
+++ b/example.js
@@ -1,11 +1,10 @@
 var control = require('./')
 
-//prepare mobile
-var meta = document.createElement('meta');
-meta.setAttribute('name', 'viewport');
-meta.setAttribute('content', 'width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=0');
-document.head.appendChild(meta);
-
+// prepare mobile
+var meta = document.createElement('meta')
+meta.setAttribute('name', 'viewport')
+meta.setAttribute('content', 'width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=0')
+document.head.appendChild(meta)
 
 var panel = control([
   {type: 'range', label: 'range slider', min: 0, max: 100, initial: 20, help: 'Default slider'},

--- a/example.js
+++ b/example.js
@@ -23,7 +23,8 @@ var panel = control([
   {type: 'interval', label: 'neg log interval', min: -0.1, max: -10, initial: [-0.1, -1], scale: 'log', steps: 20},
   {type: 'range', label: 'one more', min: 0, max: 10},
   {type: 'select', label: 'key/value select', options: {state1: 'State One', state2: 'State Two'}, initial: 'state1'},
-  {type: 'select', label: 'array select', options: ['State One', 'State Two'], initial: 'State One'}
+  {type: 'select', label: 'array select', options: ['State One', 'State Two'], initial: 'State One'},
+  {type: 'email', label: 'email'}
 ],
   {theme: 'light', title: 'example panel', position: 'top-left', width: 400}
 )

--- a/example.js
+++ b/example.js
@@ -1,5 +1,12 @@
 var control = require('./')
 
+//prepare mobile
+var meta = document.createElement('meta');
+meta.setAttribute('name', 'viewport');
+meta.setAttribute('content', 'width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=0"/> <!-');
+document.head.appendChild(meta);
+
+
 var panel = control([
   {type: 'range', label: 'range slider', min: 0, max: 100, initial: 20},
   {type: 'range', label: 'range stepped', min: 0, max: 1, step: 0.2, initial: 0.6},

--- a/example.js
+++ b/example.js
@@ -3,7 +3,7 @@ var control = require('./')
 //prepare mobile
 var meta = document.createElement('meta');
 meta.setAttribute('name', 'viewport');
-meta.setAttribute('content', 'width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=0"/> <!-');
+meta.setAttribute('content', 'width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=0');
 document.head.appendChild(meta);
 
 

--- a/index.js
+++ b/index.js
@@ -85,16 +85,18 @@ function Plate (items, opts) {
     opacity: 0.95
   })
 
-  if (opts.position === 'top-right' ||
-    opts.position === 'top-left' ||
-    opts.position === 'bottom-right' ||
-    opts.position === 'bottom-left') css(box, {position: 'absolute'})
+  if (opts.position) {
+    if (opts.position === 'top-right' ||
+      opts.position === 'top-left' ||
+      opts.position === 'bottom-right' ||
+      opts.position === 'bottom-left') css(box, {position: 'absolute'})
 
-  if (opts.position === 'top-right' || opts.position === 'bottom-right') css(box, {right: 8})
-  else css(box, {left: 8})
+    if (opts.position === 'top-right' || opts.position === 'bottom-right') css(box, {right: 8})
+    else css(box, {left: 8})
 
-  if (opts.position === 'top-right' || opts.position === 'top-left') css(box, {top: 8})
-  else css(box, {bottom: 8})
+    if (opts.position === 'top-right' || opts.position === 'top-left') css(box, {top: 8})
+    else css(box, {bottom: 8})
+  }
 
   if (opts.title) require('./components/title')(box, opts.title, opts.theme)
 

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function Plate (items, opts) {
   })
 
   items.forEach(function (item) {
-    element = components[item.type](box, item, opts.theme, id)
+    element = (components[item.type] || components.text)(box, item, opts.theme, id)
 
     element.on('initialized', function (data) {
       state[item.label] = data

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function Plate (items, opts) {
   opts.root = opts.root || document.body
   opts.position = opts.position
 
-  var box = document.createElement('div')
+  var box = document.createElement('form')
   var id = uuid()
   box.className = 'control-panel'
   box.id = 'control-panel-' + id

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function Plate (items, opts) {
   var buttoncss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'button.css'))
   var intervalcss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'interval.css'))
   var selectcss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'select.css'))
+  var valuecss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'value.css'))
 
   rangecss = String(rangecss)
     .replace(new RegExp('{{ THUMB_COLOR }}', 'g'), opts.theme.foreground1)
@@ -59,6 +60,10 @@ function Plate (items, opts) {
     .replace(new RegExp('{{ BG_COLOR }}', 'g'), opts.theme.background2)
     .replace(new RegExp('{{ BG_COLOR_HOVER }}', 'g'), opts.theme.background2hover)
     .replace(new RegExp('{{ UUID }}', 'g'), id)
+  valuecss = String(valuecss)
+    .replace(new RegExp('{{ TEXT_COLOR }}', 'g'), opts.theme.text2)
+    .replace(new RegExp('{{ BG_COLOR }}', 'g'), opts.theme.background2)
+    .replace(new RegExp('{{ UUID }}', 'g'), id)
   insertcss(basecss)
   insertcss(rangecss)
   insertcss(colorcss)
@@ -66,6 +71,7 @@ function Plate (items, opts) {
   insertcss(buttoncss)
   insertcss(intervalcss)
   insertcss(selectcss)
+  insertcss(valuecss)
 
   css(box, {
     background: opts.theme.background1,

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function Plate (items, opts) {
   opts.root = opts.root || document.body
   opts.position = opts.position
 
-  var box = document.createElement('form')
+  var box = this.box = document.createElement('form')
   var id = uuid()
   box.className = 'control-panel'
   box.id = 'control-panel-' + id

--- a/index.js
+++ b/index.js
@@ -124,6 +124,7 @@ function Plate (items, opts) {
 
     element.on('input', function (data) {
       state[item.label] = data
+      item.input && item.input(data, state)
       self.emit('input', state)
     })
   })

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var insertcss = require('insert-css')
 var path = require('path')
 var isstring = require('is-string')
 var themes = require('./themes')
-var uuid = require('node-uuid')
+var uuid = require('get-uid')
 
 module.exports = Plate
 inherits(Plate, EventEmitter)
@@ -22,7 +22,7 @@ function Plate (items, opts) {
   opts.position = opts.position
 
   var box = document.createElement('div')
-  var id = uuid.v4()
+  var id = uuid()
   box.className = 'control-panel'
   box.id = 'control-panel-' + id
 

--- a/index.js
+++ b/index.js
@@ -116,6 +116,25 @@ function Plate (items, opts) {
   })
 
   items.forEach(function (item) {
+    // detect item type, if undefined, from other options
+    if (!item.type) {
+      if (item.initial && item.initial.length) {
+        item.type = 'interval'
+      } else if (item.scale || item.max || item.steps || typeof item.initial === 'number') {
+        item.type = 'range'
+      } else if (item.options) {
+        item.type = 'select'
+      } else if (item.format) {
+        item.type = 'color'
+      } else if (typeof item.initial === 'boolean') {
+        item.type = 'checkbox'
+      } else if (item.action) {
+        item.type = 'button'
+      } else {
+        item.type = 'text'
+      }
+    }
+
     element = components[item.type](box, item, opts.theme, id)
 
     element.on('initialized', function (data) {

--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ function Plate (items, opts) {
   var valuecss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'value.css'))
 
   basecss = String(basecss)
+    .replace(new RegExp('{{ FONT_FAMILY }}', 'g'), opts.theme.fontFamily)
+    .replace(new RegExp('{{ FONT_SIZE }}', 'g'), opts.theme.fontSize)
     .replace(new RegExp('{{ HELP_COLOR }}', 'g'), opts.theme.foreground1)
   rangecss = String(rangecss)
     .replace(new RegExp('{{ THUMB_COLOR }}', 'g'), opts.theme.foreground1)

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function Plate (items, opts) {
   }
 
   var element
-  var state = {}
+  var state = this.state = {}
 
   items.forEach(function (item) {
     if (item.type !== 'button') {

--- a/index.js
+++ b/index.js
@@ -67,12 +67,6 @@ function Plate (items, opts) {
   insertcss(intervalcss)
   insertcss(selectcss)
 
-  var elem = document.createElement('style')
-  elem.setAttribute('type', 'text/css')
-  elem.setAttribute('rel', 'stylesheet')
-  elem.setAttribute('href', '//cdn.jsdelivr.net/font-hack/2.019/css/hack.min.css')
-  document.getElementsByTagName('head')[0].appendChild(elem)
-
   css(box, {
     background: opts.theme.background1,
     width: opts.width,

--- a/index.js
+++ b/index.js
@@ -116,25 +116,6 @@ function Plate (items, opts) {
   })
 
   items.forEach(function (item) {
-    // detect item type, if undefined, from other options
-    if (!item.type) {
-      if (item.initial && item.initial.length) {
-        item.type = 'interval'
-      } else if (item.scale || item.max || item.steps || typeof item.initial === 'number') {
-        item.type = 'range'
-      } else if (item.options) {
-        item.type = 'select'
-      } else if (item.format) {
-        item.type = 'color'
-      } else if (typeof item.initial === 'boolean') {
-        item.type = 'checkbox'
-      } else if (item.action) {
-        item.type = 'button'
-      } else {
-        item.type = 'text'
-      }
-    }
-
     element = components[item.type](box, item, opts.theme, id)
 
     element.on('initialized', function (data) {

--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ function Plate (items, opts) {
   var selectcss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'select.css'))
   var valuecss = fs.readFileSync(path.join(__dirname, 'components', 'styles', 'value.css'))
 
+  basecss = String(basecss)
+    .replace(new RegExp('{{ HELP_COLOR }}', 'g'), opts.theme.foreground1)
   rangecss = String(rangecss)
     .replace(new RegExp('{{ THUMB_COLOR }}', 'g'), opts.theme.foreground1)
     .replace(new RegExp('{{ TRACK_COLOR }}', 'g'), opts.theme.background2)

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   "dependencies": {
     "brfs": "^1.4.3",
     "dom-css": "^2.0.0",
+    "get-uid": "^1.0.1",
     "inherits": "^2.0.1",
     "insert-css": "^0.2.0",
     "is-numeric": "0.0.5",
     "is-string": "^1.0.4",
-    "node-uuid": "^1.4.7",
     "param-case": "^1.1.2",
     "simple-color-picker": "0.0.9",
     "tinycolor2": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "get-uid": "^1.0.1",
     "inherits": "^2.0.1",
     "insert-css": "^0.2.0",
+    "is-mobile": "^0.2.2",
     "is-numeric": "0.0.5",
     "is-string": "^1.0.4",
     "param-case": "^1.1.2",

--- a/themes.js
+++ b/themes.js
@@ -1,5 +1,7 @@
 module.exports = {
   light: {
+    fontFamily: '"Hack", monospace',
+    fontSize: '11px',
     background1: 'rgb(227,227,227)',
     background2: 'rgb(204,204,204)',
     background2hover: 'rgb(208,208,208)',
@@ -9,6 +11,8 @@ module.exports = {
   },
 
   dark: {
+    fontFamily: '"Hack", monospace',
+    fontSize: '11px',
     background1: 'rgb(35,35,35)',
     background2: 'rgb(54,54,54)',
     background2hover: 'rgb(58,58,58)',


### PR DESCRIPTION
Hi @rreusser @freeman-lab.

Here I have a list of changes discussed in #10 and related to #12.
Technically you can skim through commits, they are narrative, but in case, I list the main changes here.

* sizes are now in em's, dependent on the control-panel’s font-size. User can scale thing by setting control-panel’s font-size.
* linear ranges and intervals have synced `input[type=number]` for value instead of `div`
* #12 is solved without multirange, for the better (it works in IE!)
* labels are now actual `<label>` tags pointing to proper inputs, to allow clicking on them
* added `help` and `input` properties to components
* removed `hack` font - it saves extra-request in case if user decides to use his own font. Also `hack` was not loading by default due to error in code (`style` instead of `link` tag). One option would be using [google-fonts](http://npmjs.org/package/google-fonts), but that is a separate feature.
* some minor style/code fixes

Please review!
Looking forward to starting work on prama.

PS I think that there might be some other patches, like fixing ids, minor interactions or something, so if you don’t really mind my code style, I would really appreciate if you grant me contributor’s access to the repo and npm, to avoid delays.