### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var insertcss = require('insert-css')
 var path = require('path')
 var isstring = require('is-string')
 var themes = require('./themes')
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 
 module.exports = Plate
 inherits(Plate, EventEmitter)

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "insert-css": "^0.2.0",
     "is-numeric": "0.0.5",
     "is-string": "^1.0.4",
-    "node-uuid": "^1.4.7",
     "param-case": "^1.1.2",
     "simple-color-picker": "0.0.9",
-    "tinycolor2": "^1.3.0"
+    "tinycolor2": "^1.3.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "garnish": "^5.0.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.