### PR TITLE
Prevents color picker from not overlapping other control panels properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,8 +83,7 @@ function Plate (items, opts) {
     background: opts.theme.background1,
     width: opts.width,
     padding: '14px',
-    paddingBottom: '8px',
-    opacity: 0.95
+    paddingBottom: '8px'
   })
 
   if (opts.position === 'top-right' ||

--- a/themes.js
+++ b/themes.js
@@ -1,19 +1,19 @@
 module.exports = {
   light: {
-    background1: 'rgb(227,227,227)',
-    background2: 'rgb(204,204,204)',
-    background2hover: 'rgb(208,208,208)',
-    foreground1: 'rgb(105,105,105)',
-    text1: 'rgb(36,36,36)',
-    text2: 'rgb(87,87,87)'
+    background1: 'rgba(227,227,227,.95)',
+    background2: 'rgba(204,204,204,.95)',
+    background2hover: 'rgba(208,208,208,.95)',
+    foreground1: 'rgba(105,105,105,.95)',
+    text1: 'rgba(36,36,36,.95)',
+    text2: 'rgba(87,87,87,.95)'
   },
 
   dark: {
-    background1: 'rgb(35,35,35)',
-    background2: 'rgb(54,54,54)',
-    background2hover: 'rgb(58,58,58)',
-    foreground1: 'rgb(112,112,112)',
-    text1: 'rgb(235,235,235)',
-    text2: 'rgb(161,161,161)'
+    background1: 'rgba(35,35,35,.95)',
+    background2: 'rgba(54,54,54,.95)',
+    background2hover: 'rgba(58,58,58,.95)',
+    foreground1: 'rgba(112,112,112,.95)',
+    text1: 'rgba(235,235,235,.95)',
+    text2: 'rgba(161,161,161,.95)'
   }
 }


### PR DESCRIPTION
Addresses #1 

Annoyingly opacity creates a new z-index stacking context (it's part of the spec: https://www.w3.org/TR/css-color-3/#transparency)

So I've removed the opacity, and have used alpha transparancy in the theme colors instead