### PR TITLE
Add link to React port

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ access its current value using
 panel.state['my checkbox']
 ```
 
+#### react port
+
+This project has been ported to work with React and is available as [react-control-panel](https://github.com/ameobea/react-control-panel) on NPM.  The visual appearance is identical to that of the original, and some features have been added including externally managed state and an ES6 Proxy-based API for reading/writing the UI state remotely.
+
 #### see also
 
 - [oui](https://github.com/wearekuva/oui)


### PR DESCRIPTION
I sent an email a while ago about a [React Port of `control-panel`](https://github.com/ameobea/react-control-panel) that I made, but I don't think it got through.  The goal was to maintain 100% visual appearance and API compatibility while switching the codebase over to be written in an idiomatic React manner (no direct DOM mutation, optional component-based construction etc.).  The effort was largely a success, and I feel that it's of a high enough quality that other people may find it useful and want to use it themselves.  

I've added a small link to the bottom of the README linking to the React port.  If you prefer to host it yourself, I can change the license on it to whatever would make it possible for you to copy it (if it isn't already) and host it under the `freeman-lab` organization.  Also, if you don't want the link for whatever reason, that's fine as well.